### PR TITLE
Fix creating servers on freebsd

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -37,7 +37,11 @@ try {
   try {
     fs.statSync('/usr/compat/linux/proc/uptime');
     PROC_PATH = '/usr/compat/linux/proc';
-  } catch (e) {}
+  } catch (e) {
+      try {
+          PROC_PATH = '/proc';
+      } catch (e) {}
+  }
 }
 
 mineos.server_list = function(base_dir) {


### PR DESCRIPTION
This should fix creating servers on freebsd

On my freebsd system the /proc/uptime file does not exist so adding a new try with only PROC_PATH=/proc makes mineos-node able to create servers without any issues so far.