### PR TITLE
Multi ip broadcast

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,8 +58,7 @@ server.backend = function(base_dir, socket_emitter) {
     async.forever(
       function(next) {
         for (var s in self.servers) {
-          var server_ip = '0.0.0.0'; // I cannot for the life of me figure out how to get the MC server IP
-          self.servers[s].broadcast_to_lan(function(msg) {
+          self.servers[s].broadcast_to_lan(function(msg, server_ip) {
             if (msg) {
               if (udp_broadcaster[server_ip]) {
                 udp_broadcaster[server_ip].send(msg, 0, msg.length, UDP_PORT, UDP_DEST);
@@ -498,7 +497,8 @@ function server_container(server_name, base_dir, socket_io) {
         callback(null);
       else {
         var msg = new Buffer("[MOTD]" + sp_data.motd + "[/MOTD][AD]" + sp_data['server-port'] + "[/AD]");
-        callback(msg);
+        var server_ip = sp_data['server-ip'];
+        callback(msg, server_ip);
       }
     })
   }

--- a/server.js
+++ b/server.js
@@ -64,9 +64,13 @@ server.backend = function(base_dir, socket_emitter) {
                 udp_broadcaster[server_ip].send(msg, 0, msg.length, UDP_PORT, UDP_DEST);
               } else {
                 udp_broadcaster[server_ip] = dgram.createSocket('udp4');
-                udp_broadcaster[server_ip].bind(UDP_PORT, server_ip, function () {
+                udp_broadcaster[server_ip].bind(UDP_PORT, server_ip);
+                udp_broadcaster[server_ip].on("listening", function () {
                   udp_broadcaster[server_ip].setBroadcast(true);
                   udp_broadcaster[server_ip].send(msg, 0, msg.length, UDP_PORT, UDP_DEST);
+                });
+                udp_broadcaster[server_ip].on("error", function (err) {
+                  logging.error("Cannot bind broadcaster to ip " + server_ip);
                 });
               }
             }


### PR DESCRIPTION
The two commits enable broadcasting of Minecraft servers with different IPs but identical port numbers, as in #110. Pics or it didn't happen:

<img width="966" alt="screen shot 2015-09-10 at 00 17 26" src="https://cloud.githubusercontent.com/assets/526914/9775692/6fb1f8a6-5751-11e5-8e03-018bcd91bbd1.png">

This is my first time using node, so I'm not 100% confident about the quality of the implementation. The idea, however, I'm sure is sound :)