### PR TITLE
Applied filter kb_string_to_mb to server memory footprint

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -65,7 +65,7 @@
 
                 <!-- START Toolbar -->
                 <ul class="toolbar" id="toolbar" ng-controller="Toolbar">
-                    
+
                     <!-- START Notification -->
                     <li class="notification">
                         <a href="#" data-toggle="dropdown">
@@ -247,7 +247,7 @@
                                             <span class="text">logs/latest.log</span>
                                         </a>
                                     </li>
-                                    <!--/ END Menu -->                                    
+                                    <!--/ END Menu -->
 
                                     <!-- START Menu -->
                                     <li class="accordion-group" ng-show="current && servers[current].live_logs['server.log'].length">
@@ -440,7 +440,7 @@
                 <div class="container-fluid" ng-show="page == 'create_server'">
 
                     <!-- START General Elements -->
-                        
+
                     <header>
                         <h4 class="title"> {{ 'CREATE_NEW_SERVER' | translate }}</h4>
                     </header>
@@ -547,7 +547,7 @@
                                     <label class="control-label">generate-structures</label>
                                     <div class="controls">
                                         <label class="checkbox">
-                                            <input type="checkbox" class="nostyle" value="true" ng-model="serverform.generate_structures"> 
+                                            <input type="checkbox" class="nostyle" value="true" ng-model="serverform.generate_structures">
                                         </label>
                                     </div>
                                 </div><!--/ Default Checkbox -->
@@ -563,7 +563,7 @@
                             </div>
                         </form>
                     </section>
-                
+
                 <!--/ END General Elements -->
                 </div>
                 <!--/ END Content -->
@@ -620,7 +620,7 @@
                         <!-- START Basic Table -->
                         <div class="span12 widget">
                             <header>
-                                <h4 class="title" translate="AVAILABLE_SERVER_JARS"></h4> 
+                                <h4 class="title" translate="AVAILABLE_SERVER_JARS"></h4>
                             </header>
                             <section class="body">
                                 <div class="body-inner no-padding">
@@ -665,10 +665,10 @@
                                             </tr>
                                         </tbody>
                                         <tbody>
-                                            <tr ng-repeat="jar in profiles | 
-                                                           profile_filter: {field: 'group', value: serverprofiles.group} | 
-                                                           profile_filter: {field: 'type', value: serverprofiles.type} | 
-                                                           profile_downloaded: serverprofiles.downloaded | 
+                                            <tr ng-repeat="jar in profiles |
+                                                           profile_filter: {field: 'group', value: serverprofiles.group} |
+                                                           profile_filter: {field: 'type', value: serverprofiles.type} |
+                                                           profile_downloaded: serverprofiles.downloaded |
                                                            orderBy:['+weight', '-releaseTime', 'id']">
                                                 <td>{{ jar.id }}</td>
                                                 <td>{{ jar.webui_desc }}</td>
@@ -749,7 +749,7 @@
                                                             <span class="icon icone-ticket"></span>
                                                         </div>
                                                         <figcaption>
-                                                            <h4>{{ servers[current].heartbeat.memory.VmRSS }}&nbsp;<small translate="MEMORY_FOOTPRINT"></small></h4>
+                                                            <h4>{{ servers[current].heartbeat.memory.VmRSS | kb_string_to_mb }}&nbsp;<small translate="MEMORY_FOOTPRINT"></small></h4>
                                                         </figcaption>
                                                     </figure><!--/ END Circular -->
                                                 </div>
@@ -775,25 +775,25 @@
                                                     <div class="span4">
                                                         <div class="btn-group btn-block">
                                                             <button class="btn btn-danger span6" translate="STOP"
-                                                                    ng-disabled="!servers[current].heartbeat.up" 
+                                                                    ng-disabled="!servers[current].heartbeat.up"
                                                                     ng-click="server_command('stop')"
                                                                     ng-hide="servers[current].sc.minecraft.unconventional"
                                                                     ></button>
                                                             <button class="btn btn-danger span6" translate="KILL"
-                                                                    ng-disabled="!servers[current].heartbeat.up" 
-                                                                    ng-click="server_command('kill')" 
+                                                                    ng-disabled="!servers[current].heartbeat.up"
+                                                                    ng-click="server_command('kill')"
                                                                     ng-hide="!servers[current].sc.minecraft.unconventional"
                                                                     ></button>
                                                             <button class="btn btn-danger dropdown-toggle" data-toggle="dropdown" ng-hide="servers[current].sc.minecraft.unconventional"><span class="caret"></span></button>
                                                             <ul class="dropdown-menu" ng-hide="servers[current].sc.minecraft.unconventional">
                                                                 <li><a href="#" translate="STOP"
-                                                                       ng-click="server_command('stop')" 
+                                                                       ng-click="server_command('stop')"
                                                                        ng-disabled="!servers[current].heartbeat.up"></a></li>
                                                                 <li><a href="#" translate="STOP_AND_BACKUP"
                                                                        ng-click="server_command('stop_and_backup')"></a></li>
                                                                 <li><a href="#" translate="RESTART"
                                                                        ng-click="server_command('restart')"></a></li>
-                                                                <li><a href="#" translate="KILL" 
+                                                                <li><a href="#" translate="KILL"
                                                                        ng-click="server_command('kill')"
                                                                        ng-disabled="!servers[current].heartbeat.up"></a></li>
                                                             </ul>
@@ -809,11 +809,11 @@
                                                     <!-- Select -->
                                                     <div class="control-group">
                                                         <div class="controls">
-                                                            <select class="" 
-                                                                ng-model="myprofile" 
-                                                                data-ng-options="p as p.id group by p.group for p in profiles | 
-                                                                profile_downloaded: 'only_downloaded' | 
-                                                                orderBy:'-releaseTime'" 
+                                                            <select class=""
+                                                                ng-model="myprofile"
+                                                                data-ng-options="p as p.id group by p.group for p in profiles |
+                                                                profile_downloaded: 'only_downloaded' |
+                                                                orderBy:'-releaseTime'"
                                                                 ng-change="change_sc('minecraft', 'profile', myprofile.id)">
                                                                 <option value="" selected translate="CHANGE_PROFILE_TO"></option>
                                                             </select>
@@ -856,9 +856,9 @@
                                                         <div class="controls">
                                                             <div class="input-prepend input-append">
                                                                 <span class="add-on" translate="JAVA_XMX"></span>
-                                                                <input type="text" 
-                                                                    ng-model="servers[current].sc.java.java_xmx" 
-                                                                    ng-change="change_sc('java', 'java_xmx', servers[current].sc.java.java_xmx)" 
+                                                                <input type="text"
+                                                                    ng-model="servers[current].sc.java.java_xmx"
+                                                                    ng-change="change_sc('java', 'java_xmx', servers[current].sc.java.java_xmx)"
                                                                     ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                                                 <span class="add-on" translate="MB_ABBREVIATION"></span>
                                                             </div>
@@ -866,8 +866,8 @@
                                                         <div class="controls">
                                                             <div class="input-prepend input-append">
                                                                 <span class="add-on" translate="JAVA_XMS"></span>
-                                                                <input type="text" 
-                                                                    ng-model="servers[current].sc.java.java_xms" 
+                                                                <input type="text"
+                                                                    ng-model="servers[current].sc.java.java_xms"
                                                                     ng-change="change_sc('java', 'java_xms', servers[current].sc.java.java_xms)"
                                                                     ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                                                 <span class="add-on" translate="MB_ABBREVIATION"></span>
@@ -876,20 +876,20 @@
                                                     </div><!--/ Help Text -->
                                                     <div class="controls">
                                                         <label class="control-label" translate="ADDITIONAL_JAVA_ARGS"></label>
-                                                        <input type="text" 
+                                                        <input type="text"
                                                             class="span6"
                                                             placeholder="-XX:+DisableExplicitGC"
-                                                            ng-model="servers[current].sc.java.java_tweaks" 
-                                                            ng-change="change_sc('java', 'java_tweaks', servers[current].sc.java.java_tweaks)" 
+                                                            ng-model="servers[current].sc.java.java_tweaks"
+                                                            ng-change="change_sc('java', 'java_tweaks', servers[current].sc.java.java_tweaks)"
                                                             ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                                     </div>
                                                     <div class="controls">
                                                         <label class="control-label" translate="ADDITIONAL_JAR_ARGS"></label>
-                                                        <input type="text" 
+                                                        <input type="text"
                                                             class="span6"
                                                             placeholder="nogui"
-                                                            ng-model="servers[current].sc.java.jar_args" 
-                                                            ng-change="change_sc('java', 'jar_args', servers[current].sc.java.jar_args)" 
+                                                            ng-model="servers[current].sc.java.jar_args"
+                                                            ng-change="change_sc('java', 'jar_args', servers[current].sc.java.jar_args)"
                                                             ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                                     </div>
                                                 </div>
@@ -904,7 +904,7 @@
                                         <p>&nbsp;</p>
                                     </div>
                                     <!--/ END Row -->
-                                        
+
                                     <!-- START Row -->
                                     <div class="row-fluid">
                                         <!-- START Widget Header Badge -->
@@ -957,7 +957,7 @@
                                                     </div><!--/ Alert Error -->
                                                     <p><button type="button" class="btn btn-small btn-primary" ng-click="server_command('archive')"><span class="icone-plus"></span> {{ 'CREATE_NEW_ARCHIVE' | translate }}</button></p>
                                                 </div>
-                                                
+
                                             </section>
                                         </div>
                                         <!--/ END Widget Header Badge -->
@@ -983,7 +983,7 @@
                                                         <div class="control-group">
                                                             <div class="controls">
                                                                 {{ 'SERVER_OWNER' | translate }}: {{ '{0} ({1})'.format(
-                                                                    servers[current].page_data.glance.owner.username, 
+                                                                    servers[current].page_data.glance.owner.username,
                                                                     servers[current].page_data.glance.owner.uid) }}
                                                                 </select>
                                                             </div>
@@ -992,11 +992,11 @@
                                                     <!-- Select -->
                                                         <div class="control-group">
                                                             <div class="controls">
-                                                                {{ 'GROUP_OWNER' | translate }}: <select class="span4" 
-                                                                                                ng-model="servers[current].page_data.glance.owner.gid" 
+                                                                {{ 'GROUP_OWNER' | translate }}: <select class="span4"
+                                                                                                ng-model="servers[current].page_data.glance.owner.gid"
                                                                                                 ng-change="change_owner()">
-                                                                    <option 
-                                                                        ng-repeat="group in groups" 
+                                                                    <option
+                                                                        ng-repeat="group in groups"
                                                                         value="{{ group.gid }}"
                                                                         ng-selected="group.gid == servers[current].page_data.glance.owner.gid">{{ '{0} ({1})'.format(group.groupname, group.gid) }}</option>
                                                                 </select>
@@ -1033,7 +1033,7 @@
                                                     </div><!--/ Default Checkbox Inline -->
 
                                                 </div>
-                                                
+
                                             </section>
                                         </div>
                                         <!--/ END Widget Header Badge -->
@@ -1294,9 +1294,9 @@
                                     <div class="control-group" ng-repeat="(property, new_value) in servers[current].sp track by $index">
                                         <div class="controls">
                                             <input type="text" class="input-large" ng-value="property" readonly>
-                                            <input type="text" class="input-xlarge" 
-                                                ng-value="new_value" 
-                                                ng-change="change_sp()" 
+                                            <input type="text" class="input-xlarge"
+                                                ng-value="new_value"
+                                                ng-change="change_sp()"
                                                 ng-model="new_value"
                                                 ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                         </div>
@@ -1539,7 +1539,7 @@
                 <div class="modal-footer">
                     <button class="btn btn-primary" data-dismiss="modal" translate="SP_ADD" ng-disabled="!sp.new_attribute" ng-click="modals.close_add_sp()"></button>
                 </div>
-            </div><!--/ Modal With Animation --> 
+            </div><!--/ Modal With Animation -->
 
             <!-- Modal With Animation -->
             <div id="modal_eula" class="modal hide fade">
@@ -1556,7 +1556,7 @@
                     <button class="btn btn-warning" data-dismiss="modal" translate="RESTART" ng-click="modals.close_accept_eula_restart()" ng-show="servers[current].heartbeat.up"></button>
                     <button class="btn btn-warning" data-dismiss="modal" translate="START" ng-click="modals.close_accept_eula_start()" ng-show="!servers[current].heartbeat.up"></button>
                 </div>
-            </div><!--/ Modal With Animation --> 
+            </div><!--/ Modal With Animation -->
 
             <!-- Modal With Animation -->
             <div id="modal_new_server" class="modal hide fade">
@@ -1585,9 +1585,9 @@
                             <div class="controls">
                                 <div class="input-prepend input-append">
                                     <span class="add-on" translate="JAVA_XMX"></span>
-                                    <input type="text" 
-                                        ng-model="servers[current].sc.java.java_xmx" 
-                                        ng-change="change_sc('java', 'java_xmx', servers[current].sc.java.java_xmx)" 
+                                    <input type="text"
+                                        ng-model="servers[current].sc.java.java_xmx"
+                                        ng-change="change_sc('java', 'java_xmx', servers[current].sc.java.java_xmx)"
                                         ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                     <span class="add-on" translate="MB_ABBREVIATION"></span>
                                 </div>
@@ -1595,8 +1595,8 @@
                             <div class="controls">
                                 <div class="input-prepend input-append">
                                     <span class="add-on" translate="JAVA_XMS"></span>
-                                    <input type="text" 
-                                        ng-model="servers[current].sc.java.java_xms" 
+                                    <input type="text"
+                                        ng-model="servers[current].sc.java.java_xms"
                                         ng-change="change_sc('java', 'java_xms', servers[current].sc.java.java_xms)"
                                         ng-model-options="{ updateOn: 'default blur', debounce: {'default': 1500, 'blur': 0} }">
                                     <span class="add-on" translate="MB_ABBREVIATION"></span>
@@ -1608,7 +1608,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-success" ng-click="modals.close_new_server_start()" translate="START"></button>
                 </div>
-            </div><!--/ Modal With Animation --> 
+            </div><!--/ Modal With Animation -->
 
             <!-- Modal With Animation -->
             <div id="modal_server_from_archive" class="modal hide fade">
@@ -1622,7 +1622,7 @@
                 <div class="modal-footer">
                     <button class="btn btn-success" aria-hidden="true" translate="CREATE_FROM_ARCHIVE" ng-click="server_from_archive_create()"></button>
                 </div>
-            </div><!--/ Modal With Animation --> 
+            </div><!--/ Modal With Animation -->
 
             </section>
             <!--/ END Template Main Content -->


### PR DESCRIPTION
resolves #118 by applying kb_string_to_mb to the memory footprint field.

I apologize for all the "changes". My editor automatically trims trailing whitespace on save... I can re-make this commit if that is a problem.  The only line that was actually changed is line 752 in html/index.html

Here it is.
```
 <h4>{{ servers[current].heartbeat.memory.VmRSS }}&nbsp;<small translate="MEMORY_FOOTPRINT"></small></h4>
```
which I changed to
```
 <h4>{{ servers[current].heartbeat.memory.VmRSS | kb_string_to_mb }}&nbsp;<small translate="MEMORY_FOOTPRINT"></small></h4>
```