### PR TITLE
Missing dirs

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -1500,6 +1500,27 @@ mineos.mc = function(server_name, base_dir) {
     ], callback)
   }
 
+  self.sync_chown = function(callback) {
+    // chowns awd,bwd,cwd to the owner of cwd.
+    // duplicates functionality of chown because it does not assume sp existence
+    var chownr = require('chownr');
+
+    async.series([
+      async.apply(fs.stat, self.env.cwd),
+      function(cb) {
+        fs.stat(self.env.cwd, function(err, stat_info) {
+          async.series([
+            async.apply(fs.ensureDir, self.env.bwd),
+            async.apply(fs.ensureDir, self.env.awd),
+            async.apply(chownr, self.env.cwd, stat_info.uid, stat_info.gid),
+            async.apply(chownr, self.env.bwd, stat_info.uid, stat_info.gid),
+            async.apply(chownr, self.env.awd, stat_info.uid, stat_info.gid),
+          ], cb)
+        })
+      }
+    ], callback)
+  }
+
   return self;
 }
 

--- a/server.js
+++ b/server.js
@@ -502,6 +502,8 @@ function server_container(server_name, base_dir, socket_io) {
       HEARTBEAT_INTERVAL_MS = 5000;
 
   logging.info('[{0}] Discovered server'.format(server_name));
+  async.series([ async.apply(instance.sync_chown) ]);
+
   make_tail('logs/latest.log');
   make_tail('server.log');
   make_tail('proxy.log.0');

--- a/test/test-mineos.js
+++ b/test/test-mineos.js
@@ -1910,6 +1910,39 @@ test.chown_recursive = function(test) {
   })
 }
 
+test.sync_chown = function(test) {
+  var userid = require('userid');
+
+  var server_name = 'testing';
+  var server_path = path.join(BASE_DIR, mineos.DIRS['servers'], server_name);
+  var instance = new mineos.mc(server_name, BASE_DIR);
+
+  async.series([
+    async.apply(fs.ensureDir, server_path),
+    async.apply(fs.chown, server_path, OWNER_CREDS.uid, OWNER_CREDS.gid),
+    function(callback) {
+      test.equal(fs.statSync(instance.env.cwd).uid, OWNER_CREDS.uid);
+      test.equal(fs.statSync(instance.env.cwd).gid, OWNER_CREDS.gid);
+      callback();
+    },
+    async.apply(instance.sync_chown),
+    function(callback) {
+      test.equal(fs.statSync(instance.env.cwd).uid, OWNER_CREDS.uid);
+      test.equal(fs.statSync(instance.env.cwd).gid, OWNER_CREDS.gid);
+
+      test.equal(fs.statSync(instance.env.bwd).uid, OWNER_CREDS.uid);
+      test.equal(fs.statSync(instance.env.bwd).gid, OWNER_CREDS.gid);
+
+      test.equal(fs.statSync(instance.env.awd).uid, OWNER_CREDS.uid);
+      test.equal(fs.statSync(instance.env.awd).gid, OWNER_CREDS.gid);
+      callback();
+    }
+  ], function(err) {
+    test.ifError(err);
+    test.done();
+  })
+}
+
 test.broadcast_property = function(test) {
   var server_name = 'testing';
   var instance = new mineos.mc(server_name, BASE_DIR);


### PR DESCRIPTION
fixed issue where servers moved into /var/games/minecraft/servers/xxxx without the accompanying archive/backup dirs made the server status page data fail (ENOENT)