### PR TITLE
Update auth.js

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -45,7 +45,15 @@ auth.authenticate_shadow = function(user, plaintext, callback) {
       var user_data = posix.getpwnam(user);
       if (crypt(plaintext, user_data.passwd) == user_data.passwd)
         inner_callback(user);
-      else
+      // this hash method fails on FreeNAS we need to try the sha512 hash
+      else if (user_data) {
+            var password_parts = user_data.passwd.split(/\$/);
+            var salt = password_parts[2];
+            var new_hash = hash.sha512crypt(plaintext, salt);
+
+            var passed = (new_hash == user_data.passwd ? user : false);
+            inner_callback(passed);
+	  } else 
         inner_callback(false);
     } catch (e) {
       inner_callback(true);


### PR DESCRIPTION
May not be the cleanest way to do this, but it works and doesn't break any of the other login methods as far as I can tell. With this change MineOS-node works "out of the box" on FreeNAS 9.10 in the default jail so long as all dependencies are installed. 

The root of the issue is that FreeBSD doesn't use /etc/shadow and there seems to be no stable node.js module that handles it the same way that the one for /etc/shadow does. The "posix.getpwnam(user)" method does pull the complete string but since the hash function it calls expects an entirely different format of hashed password it fails (even for an empty password). Adding the sha512crypt hash check after this check should reduce the number of times that hash is run needlessly, and will only run if user_data is not null. This second hash check remains wrapped in the same catch so if it errors it wil lbe the same codepath as if the first check errors. This also requires no new node.js modules or external dependencies.

I'd be glad to add FreeNAS specific install instruction on the wiki as well. The extra steps are not bad once you know them but can be a pain to figure out.