### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cron": "1.1.x",
     "object-hash": "1.1.x",
     "tmp": "0.0.x",
-    "request": "2.67.x",
+    "request": "2.74.0",
     "rsync": "0.4.x",
     "etc-passwd": "0.1.x",
     "xml2js": "0.4.x",


### PR DESCRIPTION
mineos-node currently has a 12 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/hexparrot/mineos-node) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team