### PR TITLE
added /compat/linux/proc to proc_paths

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -32,7 +32,8 @@ mineos.SP_DEFAULTS = {
 var proc_paths = [
   '/usr/compat/linux/proc',
   '/system/lxproc',
-  '/proc'
+  '/proc',
+  '/compat/linux/proc'
 ]
 
 var PROC_PATH = null;


### PR DESCRIPTION
I would like to add `/compat/linux/proc` as one of the /proc/ locations .  The main reason is that this is the more common path where linprocfs is mounted on FreeBSD.  I'm particularly thinking about the "mount_linprocfs" option in the iocage jailmanager (and FreeNAS 11.1BETA) that mounts linprocfs in that same location.

FreeNAS/TrueOS will be switching over their default jail manager and plugin system to iocage soon and having MineOS look in that location will eliminate the preinit mount command that FreeNAS currently needs.
