### PR TITLE
Fix download for Minecraft versions (1.13) not hosted on Amazon AWS

### DIFF
--- a/profiles.js
+++ b/profiles.js
@@ -69,6 +69,7 @@ exports.profile_manifests = {
 	  switch(ref_obj['type']) {
 	    case 'release':
 	      item['type'] = ref_obj['type'];
+              q.push({ id: item['id'], url: ref_obj.url });
               p.push(item);
 	      break;
 	    case 'snapshot':


### PR DESCRIPTION
When downloading Minecraft 1.13 after doing a profile update, a 1kB file is saved to disk with the name `minecraft_server.1.13.jar`.  This PR is a fix for that behavior.