### PR TITLE
Update server.js - Quick Fix for BuildTools JVM Heap Size on Issue #301

### DIFF
--- a/server.js
+++ b/server.js
@@ -446,7 +446,7 @@ server.backend = function(base_dir, socket_emitter, user_config) {
             async.apply(fs.copy, bt_path, dest_path),
             function(cb) {
               var binary = which.sync('java');
-              var proc = child_process.spawn(binary, ['-jar', dest_path, '--rev', args.version], params);
+              var proc = child_process.spawn(binary, ['-Xms512M', '-jar', dest_path, '--rev', args.version], params);
 
               proc.stdout.on('data', function (data) {
                 self.front_end.emit('build_jar_output', data.toString());


### PR DESCRIPTION
This is a quick tweak to server.js that will prevent heap size errors on Build Tools spigot builds on servers with Dynamic Ram allocation where the JVM does not allocate more than 16MB by default, or other system configurations where JVM defaults are insufficient. Ideally this could be migrated to a config variable at some point.