### PR TITLE
Remove --force-local, and other FreeBSD fix

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -446,8 +446,7 @@ mineos.mc = function(server_name, base_dir) {
       case 'tgz':
       case 'tar':
         var binary = which.sync('tar');
-        var args = ['--force-local',
-                    '-xf', dest_filepath];
+        var args = ['-xf', dest_filepath];
         var params = { cwd: self.env.cwd,
                        uid: owner.uid,
                        gid: owner.gid };

--- a/server.js
+++ b/server.js
@@ -93,7 +93,7 @@ server.backend = function(base_dir, socket_emitter, user_config) {
       ], function(err, meminfo) {
         self.front_end.emit('host_heartbeat', {
           'uptime': os.uptime(),
-          'freemem': (meminfo ? meminfo['MemAvailable'] * 1024 : os.freemem()),
+          'freemem': ((meminfo && meminfo['MemAvailable']) ? meminfo['MemAvailable'] * 1024 : os.freemem()),
           'loadavg': os.loadavg()
         })
       })


### PR DESCRIPTION
tar doesn't have that option on BSDs or Mac OS X.  And, as the full path is always being used in this code-path, it's not needed anywhere AFAICT.