### PR TITLE
Fix 'checked' state of "hide password" checkbox

### DIFF
--- a/html/login.html
+++ b/html/login.html
@@ -170,6 +170,10 @@
         var MASK_PASSWORD = false;
         try {
           $('input[name=password]').attr('type', (MASK_PASSWORD ? 'password' : 'text'));
+          if (MASK_PASSWORD)
+            $('input[name=hide]').attr('checked','checked');
+          else
+            $('input[name=hide]').removeAttr('checked');
           $('input[name=hide]').on('change', function () {
             if ($(this).is(':checked'))
               $('input[name=password]').attr('type', 'password');


### PR DESCRIPTION
Make the initial state of the "Hide password" checkbox consistent with the MASK_PASSWORD variable, and the type of the relevant input element.