### PR TITLE
query doesn't work on hosts with specific server-ip

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -1581,9 +1581,9 @@ mineos.mc = function(server_name, base_dir) {
       return retval;
     }
 
-    function send_query_packet(port) {
+    function send_query_packet(port,host='localhost') {
       var net = require('net');
-      var socket = net.connect({port: port});
+      var socket = net.connect({host: host, port: port});
       var query = 'modern';
       var QUERIES = {
         'modern': '\xfe\x01',
@@ -1645,7 +1645,10 @@ mineos.mc = function(server_name, base_dir) {
     }
 
     self.sp(function(err, dict) {
-      send_query_packet(dict['server-port']);
+      if (dict['server-ip'] != '0.0.0.0')
+        send_query_packet(dict['server-port'],dict['server-ip']);
+      else
+        send_query_packet(dict['server-port']);
     })  
   }
 


### PR DESCRIPTION
When querying running servers, they may not be reachable via localhost.  For any that have a specified server-ip, use that to query the server.