### PR TITLE
Use PaperMC API to fetch jar links

### DIFF
--- a/profiles.js
+++ b/profiles.js
@@ -266,86 +266,33 @@ exports.profile_manifests = {
     } //end handler
   },
   paperspigot: {
-    name: 'PaperSpigot',
-    handler: function(profile_dir, callback) {
+    name: 'Paper',
+    request_args: {
+      url: 'https://papermc.io/api/v1/paper',
+      json: true
+    },
+    handler: function (profile_dir, body, callback) {
       var p = [];
 
       try {
-        var item = {};
+        for (var index in body.versions) {
+          var version = body.versions[index];
+          var item = new profile_template();
 
-        item['id'] = 'paperspigot-latest';
-        item['time'] = new Date().getTime();
-        item['releaseTime'] = new Date().getTime();
-        item['type'] = 'release';
-        item['group'] = 'paperspigot';
-        item['webui_desc'] = 'Latest paperclip release';
-        item['weight'] = 0;
-        item['filename'] = 'paperclip.jar';
-        item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
-        item['version'] = 0;
-        item['release_version'] = '';
-        item['url'] = 'https://ci.destroystokyo.com/job/PaperSpigot/lastSuccessfulBuild/artifact/paperclip.jar';
-        p.push(JSON.parse(JSON.stringify(item)));
+          item['id'] = '{0}-latest'.format(version);
+          item['group'] = 'papermc';
+          item['webui_desc'] = 'Latest Paper build for {0}'.format(version);
+          item['weight'] = 0;
+          item['filename'] = 'paper-{0}.jar'.format(version);
+          item['url'] = 'https://papermc.io/api/v1/paper/{0}/latest/download'.format(version);
+          item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
+          item['version'] = version;
+          item['release_version'] = version;
+          item['type'] = 'release'
 
-        item['version'] = '1072';
-        item['id'] = 'paperspigot-{0}'.format(item.version);
-        item['time'] = new Date().getTime();
-        item['releaseTime'] = new Date().getTime();
-        item['type'] = 'release';
-        item['group'] = 'paperspigot';
-        item['release_version'] = '1.11.2';
-        item['webui_desc'] = 'Paperclip build {0} (mc version: {1})'.format(item.version, item['release_version']);
-        item['weight'] = 0;
-        item['filename'] = 'paperclip.jar';
-        item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
-        item['url'] = 'https://ci.destroystokyo.com/job/PaperSpigot/{0}/artifact/paperclip.jar'.format(item.version);
-        p.push(JSON.parse(JSON.stringify(item)));
-
-        item['version'] = '916';
-        item['id'] = 'paperspigot-{0}'.format(item.version);
-        item['time'] = new Date().getTime();
-        item['releaseTime'] = new Date().getTime();
-        item['type'] = 'release';
-        item['group'] = 'paperspigot';
-        item['release_version'] = '1.10.2';
-        item['webui_desc'] = 'Paperclip build {0} (mc version: {1})'.format(item.version, item['release_version']);
-        item['weight'] = 0;
-        item['filename'] = 'paperclip.jar';
-        item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
-        item['url'] = 'https://ci.destroystokyo.com/job/PaperSpigot/{0}/artifact/paperclip.jar'.format(item.version);
-        p.push(JSON.parse(JSON.stringify(item)));
-
-        item['version'] = '773';
-        item['id'] = 'paperspigot-{0}'.format(item.version);
-        item['time'] = new Date().getTime();
-        item['releaseTime'] = new Date().getTime();
-        item['type'] = 'release';
-        item['group'] = 'paperspigot';
-        item['release_version'] = '1.9.4';
-        item['webui_desc'] = 'Paperclip build {0} (mc version: {1})'.format(item.version, item['release_version']);
-        item['weight'] = 0;
-        item['filename'] = 'paperclip.jar';
-        item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
-        item['url'] = 'https://ci.destroystokyo.com/job/PaperSpigot/{0}/artifact/paperclip.jar'.format(item.version);
-        p.push(JSON.parse(JSON.stringify(item)));
-
-        item['version'] = '443';
-        item['id'] = 'paperspigot-{0}'.format(item.version);
-        item['time'] = new Date().getTime();
-        item['releaseTime'] = new Date().getTime();
-        item['type'] = 'release';
-        item['group'] = 'paperspigot';
-        item['release_version'] = '1.8.8';
-        item['webui_desc'] = 'Paperclip build {0} (mc version: {1})'.format(item.version, item['release_version']);
-        item['weight'] = 0;
-        item['filename'] = 'paperclip.jar';
-        item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
-        item['url'] = 'https://ci.destroystokyo.com/job/PaperSpigot/{0}/artifact/Paperclip.jar'.format(item.version);
-        //uppercase Paperclip.jar for some reason (old convention, perhaps)
-        p.push(JSON.parse(JSON.stringify(item)));
-
-      } catch (e) {}
-
+          p.push(item);
+        }
+      } catch (e) { console.log(e) }
       callback(null, p);
     } //end handler
   },

--- a/profiles.js
+++ b/profiles.js
@@ -279,11 +279,11 @@ exports.profile_manifests = {
           var version = body.versions[index];
           var item = new profile_template();
 
-          item['id'] = '{0}-latest'.format(version);
+          item['id'] = 'Paper-{0}-latest'.format(version);
           item['group'] = 'papermc';
           item['webui_desc'] = 'Latest Paper build for {0}'.format(version);
           item['weight'] = 0;
-          item['filename'] = 'paper-{0}.jar'.format(version);
+          item['filename'] = 'paperclip.jar'.format(version);
           item['url'] = 'https://papermc.io/api/v1/paper/{0}/latest/download'.format(version);
           item['downloaded'] = fs.existsSync(path.join(profile_dir, item.id, item.filename));
           item['version'] = version;


### PR DESCRIPTION
This avoids having to hardcode specific versions since we can just query the endpoint https://papermc.io/api/v1/paper to get all supported protocol versions.

It's also possible to fetch the actual version number for each protocol version by querying Paper's Jenkins CI build API, but I didn't add that here. I can do that if desired.