### PR TITLE
Enable group override for Docker deployments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,29 +38,29 @@ else
   USER_UID=1000
 fi
 
-if [ "$USER_GID" ]; then
+if [ "$GROUP_GID" ]; then
   # gid specifically provided, will overwrite 1000 default
-  if [[ "$USER_GID" =~ [^0-9] ]]; then
-    echo >&2 'USER_GID must contain only numerics [0-9]'
+  if [[ "$GROUP_GID" =~ [^0-9] ]]; then
+    echo >&2 'GROUP_GID must contain only numerics [0-9]'
     exit 1
   fi
 else
-  USER_GID=1000
+  GROUP_GID=1000
 fi
 
 if getent group $GROUP_NAME >/dev/null 2>&1; then
   echo "a group named $GROUP_NAME already exists."
 else
-  groupadd -og $GROUP_NAME $USER_NAME
-  echo >&2 "Created group: $GROUP_NAME (gid: $USER_GID)"
+  groupadd -og $GROUP_GID $GROUP_NAME
+  echo >&2 "Created group: $GROUP_NAME (gid: $GROUP_GID)"
 fi
 
 if id -u $USER_NAME >/dev/null 2>&1; then
   echo "a user named $USER_NAME already exists."
 else
-  useradd -Mos /bin/false -u $USER_UID -g $USER_GID $USER_NAME
+  useradd -Mos /bin/false -u $USER_UID -g $GROUP_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
-  echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $USER_GID)"
+  echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $GROUP_GID)"
 fi
 
 if [ ! -f /etc/ssl/certs/mineos.crt ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,12 +27,22 @@ else
   USER_UID=1000
 fi
 
+if [ "$USER_GID" ]; then
+  # gid specifically provided, will overwrite 1000 default
+  if [[ "$USER_GID" =~ [^0-9] ]]; then
+    echo >&2 'USER_GID must contain only numerics [0-9]'
+    exit 1
+  fi
+else
+  USER_GID=1000
+fi
+
 if id -u $USER_NAME >/dev/null 2>&1; then
   echo "$USER_NAME already exists."
 else
-  useradd -Ms /bin/false -u $USER_UID $USER_NAME
+  useradd -Ms /bin/false -u $USER_UID -g $USER_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
-  echo >&2 "Created user: $USER_NAME (uid: $USER_UID)"
+  echo >&2 "Created user: $USER_NAME (uid: $USER_UID, guid: $USER_GID)"
 fi
 
 if [ ! -f /etc/ssl/certs/mineos.crt ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,7 @@ fi
 if id -u $USER_NAME >/dev/null 2>&1; then
   echo "$USER_NAME already exists."
 else
+  groupadd -og $USER_GID $USER_NAME
   useradd -Ms /bin/false -u $USER_UID -g $USER_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
   echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $USER_GID)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,17 @@ else
   USER_NAME=mc
 fi
 
+if [ "$GROUP_NAME" ]; then
+  # group name specifically provided, will overwrite 'mc'
+  if [[ "$GROUP_NAME" =~ [^a-zA-Z0-9] ]]; then
+    echo >&2 'GROUP_NAME must contain only alphanumerics [a-zA-Z0-9]'
+    exit 1
+  fi
+else
+  echo >&2 'GROUP_NAME not provided; defaulting to "mc"'
+  GROUP_NAME=mc
+fi
+
 if [ "$USER_UID" ]; then
   # uid specifically provided, will overwrite 1000 default
   if [[ "$USER_UID" =~ [^0-9] ]]; then
@@ -37,11 +48,11 @@ else
   USER_GID=1000
 fi
 
-if getent group $USER_NAME >/dev/null 2>&1; then
-  echo "a group named $USER_NAME already exists."
+if getent group $GROUP_NAME >/dev/null 2>&1; then
+  echo "a group named $GROUP_NAME already exists."
 else
-  groupadd -og $USER_GID $USER_NAME
-  echo >&2 "Created group: $USER_NAME (gid: $USER_GID)"
+  groupadd -og $GROUP_NAME $USER_NAME
+  echo >&2 "Created group: $GROUP_NAME (gid: $USER_GID)"
 fi
 
 if id -u $USER_NAME >/dev/null 2>&1; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ if id -u $USER_NAME >/dev/null 2>&1; then
   echo "$USER_NAME already exists."
 else
   groupadd -og $USER_GID $USER_NAME
-  useradd -Ms /bin/false -u $USER_UID -g $USER_GID $USER_NAME
+  useradd -Mos /bin/false -u $USER_UID -g $USER_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
   echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $USER_GID)"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if id -u $USER_NAME >/dev/null 2>&1; then
 else
   useradd -Ms /bin/false -u $USER_UID -g $USER_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
-  echo >&2 "Created user: $USER_NAME (uid: $USER_UID, guid: $USER_GID)"
+  echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $USER_GID)"
 fi
 
 if [ ! -f /etc/ssl/certs/mineos.crt ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,10 +37,16 @@ else
   USER_GID=1000
 fi
 
-if id -u $USER_NAME >/dev/null 2>&1; then
-  echo "$USER_NAME already exists."
+if getent group $USER_NAME >/dev/null 2>&1; then
+  echo "a group named $USER_NAME already exists."
 else
   groupadd -og $USER_GID $USER_NAME
+  echo >&2 "Created group: $USER_NAME (gid: $USER_GID)"
+fi
+
+if id -u $USER_NAME >/dev/null 2>&1; then
+  echo "a user named $USER_NAME already exists."
+else
   useradd -Mos /bin/false -u $USER_UID -g $USER_GID $USER_NAME
   echo "$USER_NAME:$USER_PASSWORD" | chpasswd
   echo >&2 "Created user: $USER_NAME (uid: $USER_UID, gid: $USER_GID)"


### PR DESCRIPTION
This PR adds the ability to set the group name and ID of the docker user which may resolve issues with permissions in certain deployments where the host system uses a non-matching uid/gid permissions. 