### PR TITLE
use_https env var docker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,4 +40,18 @@ if [ ! -f /etc/ssl/certs/mineos.crt ]; then
   sh /usr/games/minecraft/generate-sslcert.sh
 fi
 
+if [ "$USE_HTTPS" ]; then
+    if [ "$USE_HTTPS" == "true" ]; then
+        echo "Setting https to true"
+        sed -i 's/use_https = false/use_https = true/' /etc/mineos.conf
+
+    else
+        echo "Setting https to false"
+        sed -i 's/use_https = true/use_https = false/' /etc/mineos.conf
+    fi
+else
+    echo "Falling back to https true"
+    sed -i 's/use_https = false/use_https = true/' /etc/mineos.conf
+fi
+
 exec "$@"


### PR DESCRIPTION
Made USE_HTTPS variable available that will override the runtime configuration file /etc/mineos.conf