### PR TITLE
Format uptime into days, hours, and minutes.

### DIFF
--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -99,7 +99,7 @@ app.filter('kb_string_to_mb', function() {
 
 app.filter('seconds_to_time', function() {
   return function(seconds) {
-    return moment.duration(seconds, "seconds").format();
+    return moment.duration(seconds, "seconds").format('DD [days] HH [hours] mm [minutes]');
   }
 })
 


### PR DESCRIPTION
My apologies if this isn't the desired way to achieve this. I've little to no experience with js, and this seems to be working fine on my mineos installation.
Formats the uptime counter to display days instead of a large amount of hours of uptime. I'm not sure if this is an undesirable way of displaying days in the uptime or not, but it seems to be working fine on my mineos-node installation.