### PR TITLE
Fix ERR_OUT_OF_RANGE during Buffer.write()

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -1605,7 +1605,7 @@ mineos.mc = function(server_name, base_dir) {
       socket.on('connect', function() {
         var buf = Buffer.alloc(2);
 
-        buf.write(QUERIES[query], 0, query.length, 'binary');
+        buf.write(QUERIES[query], 0, QUERIES[query].length, 'binary');
         socket.write(buf);
       });
 


### PR DESCRIPTION
MineOS is currently broken; when starting a Minecraft server, the UI crashes almost immediatley with the following log entry in /var/log/mineos.log

```
{
    "date":"Sun Oct 11 2020 20:03:57 GMT-0700 (Mountain Standard Time)",
    "process":{
        "pid":14163,
        "uid":0,
        "gid":0,
        "cwd":"/",
        "execPath":"/usr/local/bin/node",
        "version":"v14.13.0",
        "argv":[
            "/usr/local/bin/node",
            "/usr/local/games/minecraft/webui.js",
            "start"
        ],
        "memoryUsage":{
            "rss":70946816,
            "heapTotal":31768576,
            "heapUsed":18430544,
            "external":3189004,
            "arrayBuffers":1617578
        }
    },
    "os":{
        "loadavg":[
            0.25244140625,
            0.67138671875,
            0.6064453125
        ],
        "uptime":195213
    },
    "trace":[
        {
            "column":3,
            "file":"buffer.js",
            "function":"validateOffset",
            "line":103,
            "method":null,
            "native":false
        },
        {
            "column":7,
            "file":"buffer.js",
            "function":"Buffer.write",
            "line":1064,
            "method":"write",
            "native":false
        },
        {
            "column":13,
            "file":"/usr/local/games/minecraft/mineos.js",
            "function":null,
            "line":1608,
            "method":null,
            "native":false
        },
        {
            "column":22,
            "file":"events.js",
            "function":"Socket.emit",
            "line":326,
            "method":"emit",
            "native":false
        },
        {
            "column":10,
            "file":"net.js",
            "function":"TCPConnectWrap.afterConnect [as oncomplete]",
            "line":1131,
            "method":"afterConnect [as oncomplete]",
            "native":false
        }
    ],
    "stack":[
        "RangeError [ERR_OUT_OF_RANGE]: The value of \"length\" is out of range. It must be >= 0 && <= 2. Received 6",
        "    at validateOffset (buffer.js:103:3)",
        "    at Buffer.write (buffer.js:1064:7)",
        "    at Socket.<anonymous> (/usr/local/games/minecraft/mineos.js:1608:13)",
        "    at Socket.emit (events.js:326:22)",
        "    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1131:10)"
    ],
    "level":"error",
    "message":"uncaughtException: The value of \"length\" is out of range. It must be >= 0 && <= 2. Received 6",
    "timestamp":"2020-10-12T03:03:57.484Z"
}
```

This was likely a dormant issue that came to be, because the modernized Buffer modules are more fussy than before. 