### PR TITLE
Change kill button to SIGKILL instead of SIGTERM

### DIFF
--- a/mineos.js
+++ b/mineos.js
@@ -886,7 +886,7 @@ mineos.mc = function(server_name, base_dir) {
     if (!(self.server_name in pids)) {
       callback(true);
     } else {
-      process.kill(pids[self.server_name].java);
+      process.kill(pids[self.server_name].java, 9);
       var iterations = 0;
 
       async.doWhilst(


### PR DESCRIPTION
Right now, the "kill" button in the web portal sends SIGTERM to the server process. However, this is more of a very gentle nudge to shut down. By changing to SIGKILL, we tell the OS to instantly stop execution of that process. This is extremely useful if for some reason the server is stalled and will not shut down (for example, if trying to load a world from a newer version of Minecraft).