### PR TITLE
Adds Default disabling of call-home in WebUi

### DIFF
--- a/mineos.conf
+++ b/mineos.conf
@@ -1,3 +1,4 @@
+enable_tally = false
 use_https = true
 socket_host = '0.0.0.0'
 socket_port = 8443

--- a/webui.js
+++ b/webui.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var TALLY_ENABLED = false
+var WEB_ROOT = "/"
 var mineos = require('./mineos');
 var server = require('./server');
 var async = require('async');

--- a/webui.js
+++ b/webui.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-var TALLY_ENABLED = false
+// Disable tally until enabled by config.
+var ENABLE_TALLY = false
 
 var mineos = require('./mineos');
 var server = require('./server');
@@ -177,8 +178,8 @@ mineos.dependencies(function(err, binaries) {
   var be = new server.backend(base_directory, io, mineos_config);
 
   if (TALLY_ENABLED) {
-  tally();
-  setInterval(tally, 7200000); //7200000 == 120min
+    tally();
+    setInterval(tally, 7200000); //7200000 == 120min
   }
 
     app.get('/', function(req, res){
@@ -252,6 +253,10 @@ mineos.dependencies(function(err, binaries) {
   var SOCKET_HOST = '0.0.0.0';
   var USE_HTTPS = true;
 
+  if ('enable_tally' in mineos_config) {
+    ENABLE_TALLY = mineos_config['enable_tally']
+  }
+ 
   if ('use_https' in mineos_config)
     USE_HTTPS = mineos_config['use_https'];
 

--- a/webui.js
+++ b/webui.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var TALLY_ENABLED = false
-var WEB_ROOT = "/"
+
 var mineos = require('./mineos');
 var server = require('./server');
 var async = require('async');
@@ -113,6 +113,7 @@ io.use(passportSocketIO.authorize({
 }));
 
 function tally(callback) {
+  if (TALLY_ENABLED) {
   var os = require('os');
   var urllib = require('urllib');
   var child_process = require('child_process');
@@ -130,6 +131,7 @@ function tally(callback) {
       tally_info['version'] = output.replace(/\n/,'');
     urllib.request('http://minecraft.codeemo.com/tally/tally-node.py', {data: tally_info}, function(){});
   })
+}
 }
 
 function read_ini(filepath) {
@@ -174,8 +176,10 @@ mineos.dependencies(function(err, binaries) {
 
   var be = new server.backend(base_directory, io, mineos_config);
 
+  if (TALLY_ENABLED) {
   tally();
   setInterval(tally, 7200000); //7200000 == 120min
+  }
 
     app.get('/', function(req, res){
         res.redirect('/admin/index.html');


### PR DESCRIPTION
I haven't seen any mention of the 'tally' function, or see any way to enable or disable it.
I've disabled it and expect to eventually add a CLI option to turn tally back on.