### PR TITLE
Issue 423: Updated Dockerfile to include java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   rlwrap \
   openjdk-16-jre-headless \
+  openjdk-8-jre-headless \
   ca-certificates-java \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
I have tested that Minecraft still works but unable to reproduce the original issue in #423. In my dev environment I do not have any "old" servers to test and I was able to create a new server off the Official Mojang 1.6.4 binary with Java 16. Changes here are purely at the recommendations in the linked ticket.