### PR TITLE
add openjdk 17 for minecraft 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   git \
   curl \
   rlwrap \
+  openjdk-17-jre-headless \
   openjdk-16-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \


### PR DESCRIPTION
2nd verse, same as [the first](https://github.com/hexparrot/mineos-node/pull/427)!

[1.18 depends on Java 17](https://minecraft.fandom.com/wiki/Java_Edition_1.18_Pre-release_2) now. This PR adds that dependency to the Dockerfile.