### PR TITLE
added option for java_binary to be set on webui.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -968,6 +968,15 @@
                                                     <!-- Select -->
                                                     <div class="control-group">
                                                         <div class="controls">
+                                                            <select class="span6" ng-model="myjavaversion" data-ng-options="j.name for j in servers[current].page_data.glance.java_versions track by j.path" ng-change="change_sc('java', 'java_binary', myjavaversion.path)">
+                                                                <option value="" selected translate="CHANGE_JAVA_VER_TO"></option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <!-- /Select -->
+                                                    <!-- Select -->
+                                                    <div class="control-group">
+                                                        <div class="controls">
                                                             <select class="span6" ng-model="myjarfile" data-ng-options="j for j in servers[current].page_data.glance.server_files" ng-change="change_sc('java', 'jarfile', myjarfile)">
                                                                 <option value="" selected translate="CHANGE_JARFILE_TO"></option>
                                                             </select>
@@ -1632,6 +1641,15 @@
                         <select class="" ng-model="myprofile" default-option="Select a profile" data-ng-options="p as p.id group by p.group for p in profiles | profile_downloaded: 'only_downloaded' | orderBy:'-releaseTime'" ng-change="change_sc('minecraft', 'profile', myprofile.id)">
                             <option value="" disabled selected translate="CHANGE_PROFILE_TO"></option>
                         </select>
+                        <!-- Select -->
+                        <div class="control-group">
+                            <div class="controls">
+                                <select class="span6" ng-model="myjavaversion" data-ng-options="j.name for j in servers[current].page_data.glance.java_versions track by j.path" ng-change="change_sc('java', 'java_binary', myjavaversion.path)">
+                                    <option value="" selected translate="CHANGE_JAVA_VER_TO"></option>
+                                </select>
+                            </div>
+                        </div>
+                        <!-- /Select -->
                         <!-- Select -->
                         <div class="control-group">
                             <div class="controls">

--- a/html/locales/locale-de_DE.json
+++ b/html/locales/locale-de_DE.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "Serverprofil auswählen",
   "CHANGE_PROFILE_TO": "Change profile to:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Change runnable jar to:",
   "ADDITIONAL_JAVA_ARGS": "Additional Java arguments:",
   "ADDITIONAL_JAR_ARGS": "Additional Jar arguments:",

--- a/html/locales/locale-en_US.json
+++ b/html/locales/locale-en_US.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "Select server profile",
   "CHANGE_PROFILE_TO": "Change profile to:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Change runnable jar to:",
   "ADDITIONAL_JAVA_ARGS": "Additional Java arguments:",
   "ADDITIONAL_JAR_ARGS": "Additional Jar arguments:",

--- a/html/locales/locale-fr_FR.json
+++ b/html/locales/locale-fr_FR.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "Mo",
   "SELECT_SERVER_PROFILE": "Sélectionner le profil du serveur",
   "CHANGE_PROFILE_TO": "Changer le profil :",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Changer le fichier jar éxécuté :",
   "ADDITIONAL_JAVA_ARGS": "Arguments Java additionnels :",
   "ADDITIONAL_JAR_ARGS": "Arguments JAR additionnels :",

--- a/html/locales/locale-it_IT.json
+++ b/html/locales/locale-it_IT.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "Seleziona profilo server",
   "CHANGE_PROFILE_TO": "Cambia il profilo:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Cambia il jar eseguibile:",
   "ADDITIONAL_JAVA_ARGS": "Argomenti Java aggiuntivi:",
   "ADDITIONAL_JAR_ARGS": "Argomenti Jar aggiuntivi:",

--- a/html/locales/locale-ja_JP.json
+++ b/html/locales/locale-ja_JP.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "サーバー プロファイルの選択",
   "CHANGE_PROFILE_TO": "プロファイルを変更:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "実行 jarを変更:",
   "ADDITIONAL_JAVA_ARGS": "追加のJava引数:",
   "ADDITIONAL_JAR_ARGS": "追加のJar引数:",

--- a/html/locales/locale-no_NB.json
+++ b/html/locales/locale-no_NB.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "Velg serverprofil",
   "CHANGE_PROFILE_TO": "Bytt profil til:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Bytt Jarfil til:",
   "ADDITIONAL_JAVA_ARGS": "Fler Java-argumenter:",
   "ADDITIONAL_JAR_ARGS": "Fler Jarargumenter:",

--- a/html/locales/locale-ru_RU.json
+++ b/html/locales/locale-ru_RU.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "Мб",
   "SELECT_SERVER_PROFILE": "Выберите профиль сервера",
   "CHANGE_PROFILE_TO": "Сменить профиль:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Сменить JAR-файл:",
   "ADDITIONAL_JAVA_ARGS": "Дополнительные аргументы Java:",
   "ADDITIONAL_JAR_ARGS": "Дополнительные аргументы Jar:",

--- a/html/locales/locale-sv_SE.json
+++ b/html/locales/locale-sv_SE.json
@@ -102,6 +102,7 @@
   "MB_ABBREVIATION": "MB",
   "SELECT_SERVER_PROFILE": "Välj server profil",
   "CHANGE_PROFILE_TO": "Byt profil till:",
+  "CHANGE_JAVA_VER_TO": "Change java version to:",
   "CHANGE_JARFILE_TO": "Byt körbar Jar till:",
   "ADDITIONAL_JAVA_ARGS": "Ytterligare Java argument:",
   "ADDITIONAL_JAR_ARGS": "Additional Jar arguments:",

--- a/java.js
+++ b/java.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const {accessSync, promises: {readdir}} = fs;
+
+
+async function getJavaVersionsAvailable (cb){
+  let toReturn = [];
+  let vers = [];
+  try{
+    vers = (await readdir(`${__dirname}/java/`, {withFileTypes: true })).filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
+  }catch(err){}
+
+  vers.forEach((ver) => {
+    let path = `${__dirname}/java/${ver}/bin/java`;
+    try{ 
+      accessSync(path,fs.constants.F_OK);
+        toReturn.push({name: ver, path});
+    }
+    catch(e){
+      console.log(`Java version ${ver} not added\npath: '${path}' doesn't exists or you don't have access`)
+    }
+  })
+  cb(null,toReturn);
+};
+
+module.exports = {getJavaVersionsAvailable};

--- a/mineos.js
+++ b/mineos.js
@@ -5,6 +5,7 @@ var async = require('async');
 var child_process = require('child_process');
 var which = require('which');
 var mineos = exports;
+var java = require('./java');
 
 mineos.DIRS = {
   'servers': 'servers',
@@ -1487,6 +1488,9 @@ mineos.mc = function(server_name, base_dir) {
         ], function(err) {
           callback(err, server_files);
         })
+        break;
+      case 'java_versions':
+        java.getJavaVersionsAvailable(callback);
         break;
       case 'autosave':
         var TIMEOUT_LENGTH = 2000;

--- a/server.js
+++ b/server.js
@@ -1275,6 +1275,7 @@ function server_container(server_name, user_config, socket_io) {
             'du_cwd': async.apply(instance.property, 'du_cwd'),
             'owner': async.apply(instance.property, 'owner'),
             'server_files': async.apply(instance.property, 'server_files'),
+            'java_versions': async.apply(instance.property, 'java_versions'),
             'ftb_installer': async.apply(instance.property, 'FTBInstall.sh'),
             'eula': async.apply(instance.property, 'eula'),
             'base_dir': function(cb) {


### PR DESCRIPTION
'/usr/games/minecraft/java/{javaver}/bin/java' must exist

extract a downloaded java package to a 'java' folder in your mineos install folder i.e. /usr/games/minecraft/java
should still work if your mineos install is not /usr/games/minecraft as long as there is a 'java' folder in the install directory