### PR TITLE
Development Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,58 @@
+FROM ubuntu:focal as build
+LABEL MAINTAINER='William Dizon <wdchromium@gmail.com>'
+
+#set build directory
+WORKDIR /build
+
+#install necessary build dependancies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+  curl \
+  build-essential \
+  && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
+  && apt-get install -y nodejs
+
+# copy package.json and npm install
+# by copying package.json first we stop changes in other files from triggerig a rebuild of this image stage
+COPY package.json /build
+RUN npm install
+
+#copy other files to build dir
+COPY . /build
+
+#final image
+FROM ubuntu:focal
+
+WORKDIR /usr/games/minecraft
+
+#install necessary run dependancies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+  rdiff-backup \
+  screen \
+  rsync \
+  git \
+  curl \
+  rlwrap \
+  openjdk-17-jre-headless \
+  openjdk-8-jre-headless \
+  ca-certificates-java \
+  && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
+  && apt-get install -y nodejs \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /build /usr/games/minecraft
+RUN cp /usr/games/minecraft/mineos.conf /etc/mineos.conf \
+  && cp /usr/games/minecraft/entrypoint.sh /entrypoint.sh
+
+#set start command and entrypoint
+CMD ["node", "webui.js"]
+ENTRYPOINT ["/entrypoint.sh"]
+
+#set image ports volumes and envs
+EXPOSE 8443 25565-25570
+VOLUME /var/games/minecraft
+VOLUME /etc/ssl/certs
+ENV USER_PASSWORD=random_see_log USER_NAME=mc USER_UID=1000 USE_HTTPS=true SERVER_PORT=8443


### PR DESCRIPTION
This pull request adds a new dockerfile for development use

This docker-file can be used instead of the default one by using the `-f Dockerfile.dev` option of `docker build`.
Example:
`docker build -f Dockerfile.dev -t mineos-test:1.7 -t mineos-test:latest .`

It implements some dockerfile best practices from this article [https://docs.docker.com/develop/develop-images/dockerfile_best-practices/](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)

This dockerfile makes use of multi-stage builds so that build dependancies can be cached more efficiently. This means that for minor code changes, new images can be built in seconds allowing fast, easy code testing within a docker environment. `npm install` will only be run for a new image build if the package.json file has changed. Similarly, the apt-get install steps for MineOS's runtime dependencies can be cached as well. 

Another change was to get rid of supervisor and change the CMD to `node webui.js`. The downside of this is that if the webui crashes the entire container will be killed. For use as a dev environment this is fine but this might need to be changed for a production use image.

The last change was to add `/etc/ssl/certs` as a volume mount. This means that SSL certs can be kept between container instances.

Imaged produced by this dockerfile have a compressed size of about 266 MB