### PR TITLE
Split get_page_data function to improve server response time

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1200,6 +1200,8 @@
                                         </ul>
                                     </li>
                                 </ul>
+                                <button type="button" class="btn btn-mini btn-success pull-right" ng-click="servers[current].refresh_increment_sizes()" translate="GET_INCREMENT_SIZES"></button>
+                                
                                 <!--/ END Toolbar -->
                             </header>
                             <section class="body">
@@ -1218,8 +1220,8 @@
                                             <tr ng-repeat="incr in servers[current].increments">
                                                 <td>{{ incr.step }}</td>
                                                 <td>{{ incr.time | amDateFormat: "dddd, MMMM Do YYYY, h:mm:ss a" }}</td>
-                                                <td>{{ incr.size }}</td>
-                                                <td>{{ incr.cum }}</td>
+                                                <td>{{ (servers[current].data_statis.increment_sizes == 'loading') ? "Loading..." : incr.size }}</td>
+                                                <td>{{ (servers[current].data_statis.increment_sizes == 'loading') ? "Loading..." : incr.cum }}</td>
                                                 <td>
                                                     <p>
                                                         <button type="button" class="btn btn-mini btn-success" ng-click="server_command('restore', {step: incr.step})" translate="RESTORE"></button>

--- a/html/index.html
+++ b/html/index.html
@@ -1042,12 +1042,12 @@
                                         <div class="span6 widget">
                                             <header>
                                                 <h4 class="title"><span class="icon icone-hdd"></span> {{ 'RESTORE_POINTS' | translate }}</h4>
-                                                <span class="badge badge-success pull-right" ng-click="change_page('restore_points')">{{ servers[current].page_data.increments.length }}</span>
+                                                <span class="badge badge-success pull-right" ng-click="change_page('restore_points')">{{ servers[current].increments.length }}</span>
                                             </header>
                                             <section class="body">
                                                 <div class="body-inner">
-                                                    <p>{{ 'MOST_RECENT_RESTORE_POINT' | translate }}: <a rel="tooltip" title="{{ servers[current].page_data.increments[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.increments[0].time"></a></p>
-                                                    <p>{{ 'OLDEST_RESTORE_POINT' | translate }}: <a href="#" rel="tooltip" title="{{ servers[current].page_data.increments.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.increments.slice(-1)[0].time"></a></p>
+                                                    <p>{{ 'MOST_RECENT_RESTORE_POINT' | translate }}: <a rel="tooltip" title="{{ servers[current].increments[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].increments[0].time"></a></p>
+                                                    <p>{{ 'OLDEST_RESTORE_POINT' | translate }}: <a href="#" rel="tooltip" title="{{ servers[current].increments.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].increments.slice(-1)[0].time"></a></p>
                                                     <p>{{ 'SPACE_USED_RESTORES' | translate }}: {{ servers[current].page_data.glance.du_bwd | bytes_to_mb }}</p>
                                                     <!-- Alert Error -->
                                                     <div class="alert alert-success" ng-show="servers[current].latest_notice['backup'].success">
@@ -1069,12 +1069,12 @@
                                         <div class="span6 widget">
                                             <header>
                                                 <h4 class="title"><span class="icon icone-hdd"></span> {{ 'ARCHIVES' | translate }}</h4>
-                                                <span class="badge badge-success pull-right" ng-click="change_page('archives')">{{ servers[current].page_data.archives.length }}</span>
+                                                <span class="badge badge-success pull-right" ng-click="change_page('archives')">{{ servers[current].archives.length }}</span>
                                             </header>
                                             <section class="body">
                                                 <div class="body-inner">
-                                                    <p>{{ 'MOST_RECENT_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.archives[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.archives[0].time"></a></p>
-                                                    <p>{{ 'OLDEST_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.archives.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.archives.slice(-1)[0].time"></a></p>
+                                                    <p>{{ 'MOST_RECENT_ARCHIVE' | translate }}: <a title="{{ servers[current].archives[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].archives[0].time"></a></p>
+                                                    <p>{{ 'OLDEST_ARCHIVE' | translate }}: <a title="{{ servers[current].archives.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].archives.slice(-1)[0].time"></a></p>
                                                     <p>{{ 'SPACE_USED_ARCHIVES' | translate }}: {{ servers[current].page_data.glance.du_awd | bytes_to_mb }}</p>
                                                     <!-- Alert Error -->
                                                     <div class="alert alert-success" ng-show="servers[current].latest_notice['archive'].success">
@@ -1215,7 +1215,7 @@
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <tr ng-repeat="incr in servers[current].page_data.increments">
+                                            <tr ng-repeat="incr in servers[current].increments">
                                                 <td>{{ incr.step }}</td>
                                                 <td>{{ incr.time | amDateFormat: "dddd, MMMM Do YYYY, h:mm:ss a" }}</td>
                                                 <td>{{ incr.size }}</td>
@@ -1270,7 +1270,7 @@
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <tr ng-repeat="archive in servers[current].page_data.archives">
+                                            <tr ng-repeat="archive in servers[current].archives">
                                                 <td>{{ archive.time | amDateFormat: "dddd, MMMM Do YYYY, h:mm:ss a"  }}</td>
                                                 <td>{{ archive.size | bytes_to_mb }}</td>
                                                 <td>{{ archive.filename }}</td>

--- a/html/index.html
+++ b/html/index.html
@@ -1042,12 +1042,12 @@
                                         <div class="span6 widget">
                                             <header>
                                                 <h4 class="title"><span class="icon icone-hdd"></span> {{ 'RESTORE_POINTS' | translate }}</h4>
-                                                <span class="badge badge-success pull-right" ng-click="change_page('restore_points')">{{ servers[current].page_data.glance.increments.length }}</span>
+                                                <span class="badge badge-success pull-right" ng-click="change_page('restore_points')">{{ servers[current].page_data.increments.length }}</span>
                                             </header>
                                             <section class="body">
                                                 <div class="body-inner">
-                                                    <p>{{ 'MOST_RECENT_RESTORE_POINT' | translate }}: <a rel="tooltip" title="{{ servers[current].page_data.glance.increments[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.glance.increments[0].time"></a></p>
-                                                    <p>{{ 'OLDEST_RESTORE_POINT' | translate }}: <a href="#" rel="tooltip" title="{{ servers[current].page_data.glance.increments.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.glance.increments.slice(-1)[0].time"></a></p>
+                                                    <p>{{ 'MOST_RECENT_RESTORE_POINT' | translate }}: <a rel="tooltip" title="{{ servers[current].page_data.increments[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.increments[0].time"></a></p>
+                                                    <p>{{ 'OLDEST_RESTORE_POINT' | translate }}: <a href="#" rel="tooltip" title="{{ servers[current].page_data.increments.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" am-time-ago="servers[current].page_data.increments.slice(-1)[0].time"></a></p>
                                                     <p>{{ 'SPACE_USED_RESTORES' | translate }}: {{ servers[current].page_data.glance.du_bwd | bytes_to_mb }}</p>
                                                     <!-- Alert Error -->
                                                     <div class="alert alert-success" ng-show="servers[current].latest_notice['backup'].success">
@@ -1069,12 +1069,12 @@
                                         <div class="span6 widget">
                                             <header>
                                                 <h4 class="title"><span class="icon icone-hdd"></span> {{ 'ARCHIVES' | translate }}</h4>
-                                                <span class="badge badge-success pull-right" ng-click="change_page('archives')">{{ servers[current].page_data.glance.archives.length }}</span>
+                                                <span class="badge badge-success pull-right" ng-click="change_page('archives')">{{ servers[current].page_data.archives.length }}</span>
                                             </header>
                                             <section class="body">
                                                 <div class="body-inner">
-                                                    <p>{{ 'MOST_RECENT_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.glance.archives[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.glance.archives[0].time"></a></p>
-                                                    <p>{{ 'OLDEST_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.glance.archives.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.glance.archives.slice(-1)[0].time"></a></p>
+                                                    <p>{{ 'MOST_RECENT_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.archives[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.archives[0].time"></a></p>
+                                                    <p>{{ 'OLDEST_ARCHIVE' | translate }}: <a title="{{ servers[current].page_data.archives.slice(-1)[0].time | amDateFormat:'dddd, MMMM Do YYYY, h:mm:ss a' }}" rel="tooltip" am-time-ago="servers[current].page_data.archives.slice(-1)[0].time"></a></p>
                                                     <p>{{ 'SPACE_USED_ARCHIVES' | translate }}: {{ servers[current].page_data.glance.du_awd | bytes_to_mb }}</p>
                                                     <!-- Alert Error -->
                                                     <div class="alert alert-success" ng-show="servers[current].latest_notice['archive'].success">
@@ -1215,7 +1215,7 @@
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <tr ng-repeat="incr in servers[current].page_data.glance.increments">
+                                            <tr ng-repeat="incr in servers[current].page_data.increments">
                                                 <td>{{ incr.step }}</td>
                                                 <td>{{ incr.time | amDateFormat: "dddd, MMMM Do YYYY, h:mm:ss a" }}</td>
                                                 <td>{{ incr.size }}</td>
@@ -1270,7 +1270,7 @@
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <tr ng-repeat="archive in servers[current].page_data.glance.archives">
+                                            <tr ng-repeat="archive in servers[current].page_data.archives">
                                                 <td>{{ archive.time | amDateFormat: "dddd, MMMM Do YYYY, h:mm:ss a"  }}</td>
                                                 <td>{{ archive.size | bytes_to_mb }}</td>
                                                 <td>{{ archive.filename }}</td>

--- a/html/index.html
+++ b/html/index.html
@@ -1200,6 +1200,7 @@
                                         </ul>
                                     </li>
                                 </ul>
+                                <!-- button is put after dropdown, pull-right class makes them float to the right order -->
                                 <button type="button" class="btn btn-mini btn-success pull-right" ng-click="servers[current].refresh_increment_sizes()" translate="GET_INCREMENT_SIZES"></button>
                                 
                                 <!--/ END Toolbar -->

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -721,6 +721,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
 
   $scope.refresh_calendar = function() {
     var events = [];
+    console.log('Refreshing calendar')
     for (var server_name in Servers) {
       try { //archives
         Servers[server_name].archives.forEach(function(value, idx) {
@@ -767,6 +768,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
   }
 
   $scope.change_page = function(page, server_name) {
+    console.log(`changed page to ${page} ${server_name}`)
     if (server_name) {
       $scope.current = server_name;
       $scope.servers[$scope.current].refresh_all_data();
@@ -816,6 +818,11 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     me.server_name = server_name;
     me.channel = socket;
     me.page_data = {};
+    me.increments = {};
+    me.archives = {};
+    me.data_statis = {
+      increment_sizes: null
+    };
     me.live_logs = {};
     me.notices = {};
     me.latest_notice = {};
@@ -852,10 +859,12 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     })
 
     me.channel.on(server_name, 'increments', function(data) {
+      me.data_statis.increment_sizes = null;
       me.increments = data.payload;
     })
 
     me.channel.on(server_name, 'increment_sizes', function(data) {
+      me.data_statis.increment_sizes = 'ready';
       me.increments = data.payload;
     })
 
@@ -971,7 +980,10 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
 
     //request new incrments data for this server
     me.refresh_increment_sizes = function() {
-      me.channel.emit(me.server_name, 'increments');
+      if (me.data_statis.increment_sizes != 'loading') {
+        me.data_statis.increment_sizes = 'loading';
+        me.channel.emit(me.server_name, 'increment_sizes');
+      }
     }
 
     // request new cron data for this server

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -721,7 +721,6 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
 
   $scope.refresh_calendar = function() {
     var events = [];
-    console.log('Refreshing calendar')
     for (var server_name in Servers) {
       try { //archives
         Servers[server_name].archives.forEach(function(value, idx) {
@@ -768,7 +767,6 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
   }
 
   $scope.change_page = function(page, server_name) {
-    console.log(`changed page to ${page} ${server_name}`)
     if (server_name) {
       $scope.current = server_name;
       $scope.servers[$scope.current].refresh_all_data();

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -818,8 +818,8 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     me.server_name = server_name;
     me.channel = socket;
     me.page_data = {};
-    me.increments = {};
-    me.archives = {};
+    me.increments = [];
+    me.archives = [];
     me.data_statis = {
       increment_sizes: null
     };
@@ -859,8 +859,11 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     })
 
     me.channel.on(server_name, 'increments', function(data) {
-      me.data_statis.increment_sizes = null;
-      me.increments = data.payload;
+      // only replace increments data if a change has occoured
+      if (data.payload.length != me.increments) {
+        me.data_statis.increment_sizes = null;
+        me.increments = data.payload;
+      }
     })
 
     me.channel.on(server_name, 'increment_sizes', function(data) {
@@ -922,6 +925,9 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
         me.refresh_archives();
 
       if(data.command == 'backup')
+        me.refresh_increments();
+
+      if(data.command == 'prune')
         me.refresh_increments();
 
       var suppress = false;
@@ -996,6 +1002,11 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
       me.channel.emit(me.server_name, 'server-icon.png');
       me.channel.emit(me.server_name, 'server.config');
       me.channel.emit(me.server_name, 'server.properties');
+    }
+
+    me.get_calendar_data = function() {
+      me.refresh_increments();
+      me.refresh_archives();
     }
 
     //request minimum data for use by dashboard before returning constructed server

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -818,7 +818,7 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     me.page_data = {};
     me.increments = [];
     me.archives = [];
-    me.data_statis = {
+    me.data_status = {
       increment_sizes: null
     };
     me.live_logs = {};
@@ -857,15 +857,15 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     })
 
     me.channel.on(server_name, 'increments', function(data) {
-      // only replace increments data if a change has occoured
-      if (data.payload.length != me.increments) {
-        me.data_statis.increment_sizes = null;
+      // only replace increments data if a change has occurred
+      if (data.payload.length != me.increments.length) {
+        me.data_status.increment_sizes = null;
         me.increments = data.payload;
       }
     })
 
     me.channel.on(server_name, 'increment_sizes', function(data) {
-      me.data_statis.increment_sizes = 'ready';
+      me.data_status.increment_sizes = 'ready';
       me.increments = data.payload;
     })
 
@@ -984,8 +984,8 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
 
     //request new incrments data for this server
     me.refresh_increment_sizes = function() {
-      if (me.data_statis.increment_sizes != 'loading') {
-        me.data_statis.increment_sizes = 'loading';
+      if (me.data_status.increment_sizes != 'loading') {
+        me.data_status.increment_sizes = 'loading';
         me.channel.emit(me.server_name, 'increment_sizes');
       }
     }

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -1010,7 +1010,8 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     }
 
     //request minimum data for use by dashboard before returning constructed server
-    me.get_dashboard_data()
+    me.get_dashboard_data();
+    me.get_calendar_data();
     return me;
   }
 

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -723,7 +723,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
     var events = [];
     for (var server_name in Servers) {
       try { //archives
-        Servers[server_name].page_data.archives.forEach(function(value, idx) {
+        Servers[server_name].archives.forEach(function(value, idx) {
           events.push({
             title: '{0} archive'.format(server_name),
             start: value.time,
@@ -733,7 +733,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
       } catch (e) {}
 
       try { //backups
-        Servers[server_name].page_data.increments.forEach(function(value, idx) {
+        Servers[server_name].increments.forEach(function(value, idx) {
           events.push({
             title: '{0} backup'.format(server_name),
             start: value.time,
@@ -847,6 +847,18 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
       me.page_data[data.page] = data.payload;
     })
 
+    me.channel.on(server_name, 'archives', function(data) {
+      me.archives = data.payload;
+    })
+
+    me.channel.on(server_name, 'increments', function(data) {
+      me.increments = data.payload;
+    })
+
+    me.channel.on(server_name, 'increment_sizes', function(data) {
+      me.increments = data.payload;
+    })
+
     me.channel.on(server_name, 'tail_data', function(data) {
       try {
         if (me.auto_rate_interval) {
@@ -949,12 +961,17 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
 
     //request new incrments data for this server
     me.refresh_increments = function() {
-      me.channel.emit(me.server_name, 'page_data', 'increments');
+      me.channel.emit(me.server_name, 'increments');
     }
 
     //request new archives data for this server
     me.refresh_archives = function() {
-      me.channel.emit(me.server_name, 'page_data', 'archives');
+      me.channel.emit(me.server_name, 'archives');
+    }
+
+    //request new incrments data for this server
+    me.refresh_increment_sizes = function() {
+      me.channel.emit(me.server_name, 'increments');
     }
 
     // request new cron data for this server

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -835,7 +835,7 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
       me.heartbeat = data.payload;
 
       if ((previous_state || {}).up == true && me.heartbeat.up == false) {
-        me.channel.emit(server_name, 'page_data', 'glance');
+        me.refresh_glance();
         $.gritter.add({
           title: "[{0}] {1}".format(me.server_name, $filter('translate')('DOWN') ),
           text: ''
@@ -895,7 +895,7 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
     me.channel.on(server_name, 'server_fin', function(data) {
       me.notices[data.uuid] = data;
       me.latest_notice[data.command] = data;
-      me.channel.emit(server_name, 'page_data', 'glance');
+      me.refresh_glance();
 
       if(data.command == 'archive')
         me.refresh_archives();

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -723,7 +723,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
     var events = [];
     for (var server_name in Servers) {
       try { //archives
-        Servers[server_name].page_data.glance.archives.forEach(function(value, idx) {
+        Servers[server_name].page_data.archives.forEach(function(value, idx) {
           events.push({
             title: '{0} archive'.format(server_name),
             start: value.time,
@@ -733,7 +733,7 @@ app.controller("Webui", ['$scope', 'socket', 'Servers', '$filter', '$translate',
       } catch (e) {}
 
       try { //backups
-        Servers[server_name].page_data.glance.increments.forEach(function(value, idx) {
+        Servers[server_name].page_data.increments.forEach(function(value, idx) {
           events.push({
             title: '{0} backup'.format(server_name),
             start: value.time,
@@ -889,6 +889,12 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
       me.latest_notice[data.command] = data;
       me.channel.emit(server_name, 'page_data', 'glance');
 
+      if(data.command == 'archive')
+        me.channel.emit(server_name, 'page_data', 'archives');
+
+      if(data.command == 'backup')
+        me.channel.emit(server_name, 'page_data', 'increments');
+
       var suppress = false;
       if ('suppress_popup' in data || data.success)
         suppress = true;
@@ -918,6 +924,8 @@ app.factory("Servers", ['socket', '$filter', function(socket, $filter) {
 
     me.channel.emit(server_name, 'server-icon.png');
     me.channel.emit(server_name, 'page_data', 'glance');
+    me.channel.emit(server_name, 'page_data', 'increments');
+    me.channel.emit(server_name, 'page_data', 'archives');
     me.channel.emit(server_name, 'get_available_tails');
     me.channel.emit(server_name, 'req_server_activity');
     me.channel.emit(server_name, 'config.yml');

--- a/html/locales/locale-en_US.json
+++ b/html/locales/locale-en_US.json
@@ -116,6 +116,7 @@
   "FAILURE": "Uh oh!",
   "RESTORE_POINT_FAILED": "Restore point attempt failed",
   "CREATE_NEW_RESTORE_POINT": "Create a new restore point",
+  "GET_INCREMENT_SIZES": "Get Restore Point Sizes (slow)",
 
   "MOST_RECENT_ARCHIVE": "Most recent archive",
   "OLDEST_ARCHIVE": "Oldest Archive",

--- a/mineos.js
+++ b/mineos.js
@@ -1110,7 +1110,8 @@ mineos.mc = function(server_name, base_dir) {
 
     rdiff.stdout.on('data', function(data) {
       var buffer = Buffer.from(data, 'ascii');
-      var lines = buffer.toString('ascii').split('\n');
+      // --list-incremets option returns increments in reverse order
+      var lines = buffer.toString('ascii').split('\n').reverse();
       var incrs = 0;
 
       for (var i=0; i < lines.length; i++) {
@@ -1134,8 +1135,9 @@ mineos.mc = function(server_name, base_dir) {
     });
 
     rdiff.on('exit', function(code) {
-      if (code == 0) // branch if all is well
+      if (code == 0) { // branch if all is well
         callback(code, increment_lines);
+      }
       else // branch if dir exists, not an rdiff-backup dir
         callback(true, []);
     });

--- a/profiles.d/mojang.js
+++ b/profiles.d/mojang.js
@@ -20,7 +20,13 @@ exports.profile = {
           inner_cb(response.statusCode != 200, body)
         },
         function (body, inner_cb) {
-          var parsed = JSON.parse(body);
+          try {
+            var parsed = JSON.parse(body);
+          } catch (err) {
+            callback(err);
+            inner_cb(err);
+            return;
+          }
           for (var idx in p)
             if (p[idx]['id'] == obj['id'])
               try {

--- a/profiles.d/papertemplate.js
+++ b/profiles.d/papertemplate.js
@@ -46,7 +46,8 @@ return {
     
           p.push(item);
         })
-      }).then(() => { callback(null, p)});
+      }).then(() => { callback(null, p)})
+      .catch((err) => {console.error(err)});
       
     } catch (e) { console.log(e) }
   } //end handler

--- a/server.js
+++ b/server.js
@@ -1262,6 +1262,33 @@ function server_container(server_name, user_config, socket_io) {
       })
     }
 
+    function get_archives() {
+      logging.debug('[{0}] {1} requesting server archives'.format(server_name, username));
+      instance.list_archives(function(err, results) {
+        if (err)
+          logging.error('[{0}] Error with get_archives'.format(server_name), err, results)
+        nsp.emit('archives', {payload: results});
+      })
+    }
+
+    function get_increments() {
+      logging.debug('[{0}] {1} requesting server increments'.format(server_name, username));
+      instance.list_increments(function(err, results) {
+        if (err)
+          logging.error('[{0}] Error with get_increments'.format(server_name), err, results)
+        nsp.emit('increments', {payload: results});
+      })
+    }
+
+    function get_increment_sizes() {
+      logging.debug('[{0}] {1} requesting server increment sizes'.format(server_name, username));
+      instance.list_increment_sizes(function(err, results) {
+        if (err)
+          logging.error('[{0}] Error with get_increment_sizes'.format(server_name), err, results)
+        nsp.emit('increment_sizes', {payload: results});
+      })
+    }
+
     function get_page_data(page) {
       switch (page) {
         case 'glance':
@@ -1281,24 +1308,6 @@ function server_container(server_name, user_config, socket_io) {
           }, function(err, results) {
             if (err instanceof Object)
               logging.error('[{0}] Error with get_page_data glance'.format(server_name), err, results);
-            nsp.emit('page_data', {page: page, payload: results});
-          })
-          break;
-
-        case 'increments':
-          logging.debug('[{0}] {1} requesting server increments'.format(server_name, username));
-          instance.list_increments(function(err, results) {
-            if (err)
-              logging.error('[{0}] Error with get_page_data increments'.format(server_name), err, results)
-            nsp.emit('page_data', {page: page, payload: results});
-          })
-          break;
-
-        case 'archives':
-          logging.debug('[{0}] {1} requesting server archives'.format(server_name, username));
-          instance.list_archives(function(err, results) {
-            if (err)
-              logging.error('[{0}] Error with get_page_data archives'.format(server_name), err, results)
             nsp.emit('page_data', {page: page, payload: results});
           })
           break;
@@ -1419,6 +1428,9 @@ function server_container(server_name, user_config, socket_io) {
         socket.on('get_available_tails', get_available_tails);
         socket.on('property', get_prop);
         socket.on('page_data', get_page_data);
+        socket.on('archives', get_archives);
+        socket.on('increments', get_increments);
+        socket.on('increment_sizes', get_increment_sizes);
         socket.on('cron', manage_cron);
         socket.on('server.properties', broadcast_sp);
         socket.on('server.config', broadcast_sc);

--- a/server.js
+++ b/server.js
@@ -1268,8 +1268,6 @@ function server_container(server_name, user_config, socket_io) {
           logging.debug('[{0}] {1} requesting server at a glance info'.format(server_name, username));
 
           async.parallel({
-            'increments': async.apply(instance.list_increments),
-            'archives': async.apply(instance.list_archives),
             'du_awd': async.apply(instance.property, 'du_awd'),
             'du_bwd': async.apply(instance.property, 'du_bwd'),
             'du_cwd': async.apply(instance.property, 'du_cwd'),
@@ -1282,10 +1280,29 @@ function server_container(server_name, user_config, socket_io) {
             }
           }, function(err, results) {
             if (err instanceof Object)
-              logging.error('[{0}] Error with get_page_data'.format(server_name), err, results);
+              logging.error('[{0}] Error with get_page_data glance'.format(server_name), err, results);
             nsp.emit('page_data', {page: page, payload: results});
           })
           break;
+
+        case 'increments':
+          logging.debug('[{0}] {1} requesting server increments'.format(server_name, username));
+          instance.list_increments(function(err, results) {
+            if (err)
+              logging.error('[{0}] Error with get_page_data increments'.format(server_name), err, results)
+            nsp.emit('page_data', {page: page, payload: results});
+          })
+          break;
+
+        case 'archives':
+          logging.debug('[{0}] {1} requesting server archives'.format(server_name, username));
+          instance.list_archives(function(err, results) {
+            if (err)
+              logging.error('[{0}] Error with get_page_data archives'.format(server_name), err, results)
+            nsp.emit('page_data', {page: page, payload: results});
+          })
+          break;
+
         default:
           nsp.emit('page_data', {page: page});
           break;

--- a/test/test-mineos.js
+++ b/test/test-mineos.js
@@ -1519,7 +1519,7 @@ test.prune = function(test) {
       })
     },
     function(callback) {
-      instance.list_increments(function(err, increments) {
+      instance.list_increment_sizes(function(err, increments) {
         test.equal(increments.length, 2);
         test.equal(increments[0].step, '0B');
         test.equal(increments[1].step, '1B');
@@ -1534,7 +1534,7 @@ test.prune = function(test) {
       })
     },
     function(callback) {
-      instance.list_increments(function(err, increments) {
+      instance.list_increment_sizes(function(err, increments) {
         test.equal(increments.length, 1);
         test.equal(increments[0].step, '0B');
         test.equal(saved_increment, increments[0].time);
@@ -2794,20 +2794,20 @@ test.onreboot = function(test) {
   })
 }
 
-test.list_increments = function(test) {
+test.list_increment_sizes = function(test) {
   var server_name = 'testing';
   var instance = new mineos.mc(server_name, BASE_DIR);
 
   async.series([
     function(callback) {
-      instance.list_increments(function(err, increments) {
+      instance.list_increment_sizes(function(err, increments) {
         test.ok(err); // testing for error
         callback(!err);
       })
     },
     async.apply(instance.create, OWNER_CREDS),
     function(callback) {
-      instance.list_increments(function(err, increments) {
+      instance.list_increment_sizes(function(err, increments) {
         test.ok(err); // testing for error
         callback(!err);
       })
@@ -2829,7 +2829,7 @@ test.list_increments = function(test) {
       })
     },
     function(callback) {
-      instance.list_increments(function(err, increments) {
+      instance.list_increment_sizes(function(err, increments) {
         test.equal(increments[0].step, '0B');
         test.equal(increments[1].step, '1B');
         for (var i in increments) {

--- a/webui.js
+++ b/webui.js
@@ -315,16 +315,17 @@ mineos.dependencies(function(err, binaries) {
 
 })
 
-process.on('uncaughtException', function(err, origin) {
+process.on('uncaughtExceptionMonitor', function(err) {
   
-  // Handle the error safely
+  // Monitor but allow unhandled excaptions to fall through
   console.error(`Uncaught Exception: ${err}`);
   console.error(err.stack);
-})
+  process.exit(1);
+});
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);
-  // Application specific logging, throwing an error, or other logic here
+  process.exit(1);
 });
 
 process.on('exit', (code) => {

--- a/webui.js
+++ b/webui.js
@@ -256,8 +256,8 @@ mineos.dependencies(function(err, binaries) {
     console.log("Caught interrupt signal; closing webui....");
     be.shutdown();
     process.exit();
-  });
-
+  }); 
+  
   var SOCKET_PORT = null;
   var SOCKET_HOST = '0.0.0.0';
   var USE_HTTPS = true;
@@ -313,4 +313,20 @@ mineos.dependencies(function(err, binaries) {
 
   setInterval(session_cleanup, 3600000); //check for expired sessions every hour
 
+})
+
+process.on('uncaughtException', function(err, origin) {
+  
+  // Handle the error safely
+  console.error(`Uncaught Exception: ${err}`);
+  console.error(err.stack);
+})
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  // Application specific logging, throwing an error, or other logic here
+});
+
+process.on('exit', (code) => {
+  console.log(`About to exit with code ${code}`)
 })


### PR DESCRIPTION
This update splits the 'glance' case of the get_page_data function in server.js so that it no longer aggregates increments and archives data before responding. This improves response time of the webui.

Changed server.js to remove increments and archives from get_page_data 'glance' case.
Changed server.js to add 'increments' and 'archives' cases to get_page_data.
Changed scriptin.js to request increment and archive data when a new server is selected.
Changed scriptin.js to request new increment or archive data when a backup or archive server operation finishes.
Changed scriptin.js to accept new increment or archive data when it is sent by the server and store it on the DOM.
Changed index.html to access increment and archive data at its new location on the DOM.