### PR TITLE
Update scriptin.js

### DIFF
--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -91,7 +91,9 @@ app.filter('kb_string_to_mb', function() {
 
     if (kbytes) {
       var i = Math.floor(Math.log(kbytes) / Math.log(k));
-      return (kbytes / Math.pow(k, i)).toPrecision(3) + sizes[i];
+      var converted = kbytes / Math.pow(k, i);
+    
+      return (Math.round(converted) >= 1000 ? (converted).toPrecision(4) : (converted).toPrecision(3)) + sizes[i];
     } else {
       return '';
     }

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -77,8 +77,9 @@ app.filter('bytes_to_mb', function() {
     var k = 1024;
     var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     var i = Math.floor(Math.log(bytes) / Math.log(k));
-
-    return (bytes / Math.pow(k, i)).toPrecision(3) + sizes[i];
+    var converted = bytes / Math.pow(k, i);
+    
+    return (Math.round(converted) >= 1000 ? (converted).toPrecision(4) : (converted).toPrecision(3)) + sizes[i];
   };
 })
 


### PR DESCRIPTION
Improve the bytes_to_mb filter to precision(4) for 1000 < converted < 1024.

As the KB/MB values wrap at 1024, values between 999.5 MB and 1024 MB got converted to `1.00e+3MB` because of the `.toPrecision(3)`.