### PR TITLE
FreeBSD aarch64 releases and NetBSD requires BSD define

### DIFF
--- a/docs/install/freebsd.md
+++ b/docs/install/freebsd.md
@@ -56,7 +56,7 @@ Multiple appropriate Java editions exist, choose one to your liking:
 
 ### BUILD NODE DEPENDENCIES
 ```
-# echo "CXX=c++ npm install userid" | sh
+# echo "CXX=c++ CXXFLAGS=\"-DBSD\" npm install userid" | sh
 # echo "CXX=c++ npm install" | sh
 ```
 


### PR DESCRIPTION
The "userid" node module does not correctly build without first defining the "BSD" preprocessor flag, so we must do so on these systems.