### PR TITLE
docker build github action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,9 +51,9 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             bmcclure89/${{ env.JUST_IMAGE_NAME }}
 
-      - name: Build Docker image (non main branch)
+      - name: Build Docker image (non master branch)
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/master'
         with:
           context: .
           load: true
@@ -61,9 +61,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }} 
           build-args: TARGET_ELIXER_TAG=elixir:1.14-alpine
-      - name: Build and push Docker image (main branch)
+      - name: Build and push Docker image (master branch)
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master '
         with:
           context: .
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -60,7 +60,6 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }} 
-          build-args: TARGET_ELIXER_TAG=elixir:1.14-alpine
       - name: Build and push Docker image (master branch)
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         if: github.ref == 'refs/heads/master '
@@ -69,15 +68,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }} 
-          build-args: TARGET_ELIXER_TAG=elixir:1.14-alpine
-      - id: lowercaseImageName
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ env.IMAGE_NAME }}
-      - name: Save Docker Image archive to local filesystem
-        run: "docker save --output mineos-node.tar ${{env.REGISTRY}}/${{ steps.lowercaseImageName.outputs.lowercase }}"
-      - name: Upload application's Docker Image as pipeline artifact
-        uses: actions/upload-artifact@v2
-        with:
-          path: mineos-node.tar
-          name: mineos-node.tar


### PR DESCRIPTION
This is a workflow that I have been using to build/publish docker images on github. To push to docker hub, you need to create a [access token](https://docs.docker.com/docker-hub/access-tokens/) and set a DOCKERHUB_USERNAME and DOCKERHUB_TOKEN action secret. 

On a PR to master, or if run manually from non master branch, this workflow will build the Dockerfile, but not push. 
On any push to master, it will build, and publish to your github container registry, and docker hub

This will publish a image with the `latest`, 'master','master.commitsha' tags