### PR TITLE
redirect the spawned process stdout and stderr to the container stdout

### DIFF
--- a/init/supervisor_conf
+++ b/init/supervisor_conf
@@ -6,3 +6,9 @@ user=root
 autostart=true
 autorestart=true
 redirect_stderr=true
+redirect_stdout=true
+# https://stackoverflow.com/a/26897648
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
I am running this change in my image so that the stdout and stderr of the node process that supervisord creates will be redirected to the stdout in the container. The result is a much more streamlined ability to view logs 