### PR TITLE
"LOG_OFF" can now be translated

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -102,7 +102,7 @@
                                 <a ng-click="host_command('refresh_server_list')" class="text pointer"><span class="icon icone-globe"></span> {{ 'REFRESH_SERVER_LIST' | translate }}</a><br>
                                 <a ng-click="host_command('refresh_profile_list', {redownload: true})" class="text pointer"><span class="icon icone-globe"></span> {{ 'REFRESH_PROFILE_LIST' | translate }}</a><br>
                                 <a ng-click="modals.open_locales()" class="text pointer"><span class="icon icone-globe"></span> {{ 'CHANGE_LOCALE' | translate }}</a><br>
-                                <a href="/logout" class="text"><span class="icon icone-off"></span> {{ 'LOGOFF' | translate }}</a>
+                                <a href="/logout" class="text"><span class="icon icone-off"></span> {{ 'LOG_OFF' | translate }}</a>
                             </footer>
                         </div>
                         <!--/ END Dropdown Menu -->

--- a/html/login.html
+++ b/html/login.html
@@ -171,9 +171,9 @@
         try {
           $('input[name=password]').attr('type', (MASK_PASSWORD ? 'password' : 'text'));
           if (MASK_PASSWORD)
-            $('input[name=hide]').attr('checked','checked');
+            $('input[name=hide]').attr('');
           else
-            $('input[name=hide]').removeAttr('checked');
+            $('input[name=hide]').attr('checked');
           $('input[name=hide]').on('change', function () {
             if ($(this).is(':checked'))
               $('input[name=password]').attr('type', 'text');

--- a/html/login.html
+++ b/html/login.html
@@ -89,7 +89,7 @@
                                     <div class="controls">
                                         <span>
                                             <label class="checkbox">
-                                                <input type="checkbox" name="hide"> Hide password <a href="http://www.nngroup.com/articles/stop-password-masking/">&nbsp;(?)</a>
+                                                <input type="checkbox" name="hide"> Show password <a href="http://www.nngroup.com/articles/stop-password-masking/">&nbsp;(?)</a>
                                             </label>
                                             
                                         </span>
@@ -167,7 +167,7 @@
 
     <script type="text/javascript">
       $(document).ready(function () {
-        var MASK_PASSWORD = false;
+        var MASK_PASSWORD = true;
         try {
           $('input[name=password]').attr('type', (MASK_PASSWORD ? 'password' : 'text'));
           if (MASK_PASSWORD)
@@ -176,9 +176,9 @@
             $('input[name=hide]').removeAttr('checked');
           $('input[name=hide]').on('change', function () {
             if ($(this).is(':checked'))
-              $('input[name=password]').attr('type', 'password');
-            else
               $('input[name=password]').attr('type', 'text');
+            else
+              $('input[name=password]').attr('type', 'password');
           })
         } catch (e) {
           $('input[name=password]').attr('type', 'password');


### PR DESCRIPTION
Due to a missing underscore the logoff button wasn't using the translation.