### PR TITLE
Add subdirectory support for reverse proxy

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" ng-app="mineos"> <!--<![endif]-->
 <head>
     <!-- START META SECTION -->
+    <base href="/" >
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title translate="WEBSITE_TITLE"></title>
@@ -102,7 +103,7 @@
                                 <a ng-click="host_command('refresh_server_list')" class="text pointer"><span class="icon icone-globe"></span> {{ 'REFRESH_SERVER_LIST' | translate }}</a><br>
                                 <a ng-click="host_command('refresh_profile_list', {redownload: true})" class="text pointer"><span class="icon icone-globe"></span> {{ 'REFRESH_PROFILE_LIST' | translate }}</a><br>
                                 <a ng-click="modals.open_locales()" class="text pointer"><span class="icon icone-globe"></span> {{ 'CHANGE_LOCALE' | translate }}</a><br>
-                                <a href="/logout" class="text"><span class="icon icone-off"></span> {{ 'LOGOFF' | translate }}</a>
+                                <a href="logout" class="text"><span class="icon icone-off"></span> {{ 'LOGOFF' | translate }}</a>
                             </footer>
                         </div>
                         <!--/ END Dropdown Menu -->
@@ -1803,14 +1804,14 @@
     <!--/ Javascript(Plugins) -->
 
     <!-- Javascript (Application) -->
-    <script src="/socket.io/socket.io.js"></script>
-    <script src="/moment/min/moment.min.js"></script>
-    <script src="/angular/angular.min.js"></script>
-    <script src="/angular-translate/angular-translate.min.js"></script>
-    <script src="/angular-translate/angular-translate-loader-static-files/angular-translate-loader-static-files.min.js"></script>
-    <script src="/angular-moment/angular-moment.min.js"></script>
-    <script src="/angular-moment-duration-format/moment-duration-format.js"></script>
-    <script src="/angular-sanitize/angular-sanitize.min.js"></script>
+    <script src="socket.io/socket.io.js"></script>
+    <script src="moment/min/moment.min.js"></script>
+    <script src="angular/angular.min.js"></script>
+    <script src="angular-translate/angular-translate.min.js"></script>
+    <script src="angular-translate/angular-translate-loader-static-files/angular-translate-loader-static-files.min.js"></script>
+    <script src="angular-moment/angular-moment.min.js"></script>
+    <script src="angular-moment-duration-format/moment-duration-format.js"></script>
+    <script src="angular-sanitize/angular-sanitize.min.js"></script>
     <script src="js/scriptin.js"></script>
     <script src="js/plugins.js"></script>
     <script src="js/application.js"></script>

--- a/html/js/scriptin.js
+++ b/html/js/scriptin.js
@@ -1049,6 +1049,8 @@ app.factory('ServerService', ['socket', '$filter', function(socket, $filter) {
 app.factory('socket', function ($rootScope) {
   //http://briantford.com/blog/angular-socket-io
   var sockets = {};
+  
+  const urlBase = document.querySelector("head base").getAttribute("href");
 
   var port = window.location.port || null;
   if (port === null) {
@@ -1067,9 +1069,9 @@ app.factory('socket', function ($rootScope) {
     on: function (server_name, eventName, callback) {
       if (!(server_name in sockets)) {
         if (server_name == '/')
-          sockets[server_name] = io(connect_string, {secure: true});
+          sockets[server_name] = io(connect_string, {secure: true, path: urlBase + "socket.io"});
         else
-          sockets[server_name] = io(connect_string + server_name, {secure: true});
+          sockets[server_name] = io(connect_string + server_name, {secure: true, path: urlBase + "socket.io"});
       }
 
       sockets[server_name].on(eventName, function () {  
@@ -1082,9 +1084,9 @@ app.factory('socket', function ($rootScope) {
     emit: function (server_name, eventName, data, callback) {
       if (!(server_name in sockets)) {
         if (server_name == '/')
-          sockets[server_name] = io(connect_string, {secure: true});
+          sockets[server_name] = io(connect_string, {secure: true, path: urlBase + "socket.io"});
         else
-          sockets[server_name] = io(connect_string + server_name, {secure: true});
+          sockets[server_name] = io(connect_string + server_name, {secure: true, path: urlBase + "socket.io"});
       }
 
       sockets[server_name].emit(eventName, data, function () {

--- a/html/login.html
+++ b/html/login.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
 <head>
     <!-- START META SECTION -->
+    <base href="/" >
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>MineOS Web User Interface</title>
@@ -56,7 +57,7 @@
                 <div class="row-fluid">
                     <!-- START Login Widget Form -->
                     <p>&nbsp;</p>
-                    <form class="widget stacked teal widget-login" name="login" method="post" action="/auth">
+                    <form class="widget stacked teal widget-login" name="login" method="post" action="auth">
                         <section class="body">
                             <div class="body-inner">
                                 <!-- START Logo -->
@@ -151,13 +152,13 @@
     <!--/ Javascript(Plugins) -->
 
     <!-- Javascript (Application) -->
-    <script src="/socket.io/socket.io.js"></script>
-    <script src="/moment/min/moment.min.js"></script>
-    <script src="/angular/angular.min.js"></script>
-    <script src="/angular-translate/angular-translate.min.js"></script>
-    <script src="/angular-translate/angular-translate-loader-static-files/angular-translate-loader-static-files.min.js"></script>
-    <script src="/angular-moment/angular-moment.min.js"></script>
-    <script src="/angular-moment-duration-format/moment-duration-format.js"></script>
+    <script src="socket.io/socket.io.js"></script>
+    <script src="moment/min/moment.min.js"></script>
+    <script src="angular/angular.min.js"></script>
+    <script src="angular-translate/angular-translate.min.js"></script>
+    <script src="angular-translate/angular-translate-loader-static-files/angular-translate-loader-static-files.min.js"></script>
+    <script src="angular-moment/angular-moment.min.js"></script>
+    <script src="angular-moment-duration-format/moment-duration-format.js"></script>
     <script src="js/scriptin.js"></script>
     <script src="js/plugins.js"></script>
     <script src="js/application.js"></script>

--- a/mineos.conf
+++ b/mineos.conf
@@ -2,6 +2,7 @@ use_https = true
 socket_host = '0.0.0.0'
 socket_port = 8443
 base_directory = '/var/games/minecraft'
+overwrite_web_root = ''
 
 ssl_private_key = '/etc/ssl/certs/mineos.key'
 ssl_certificate = '/etc/ssl/certs/mineos.crt'


### PR DESCRIPTION
I added support for subdirectory, which allows the application to be accessible like this: https://myserver.com/mineos/.
Just change `overwrite_web_root` in `mineos.conf`.

Exemple:
```
use_https = true
socket_host = '0.0.0.0'
socket_port = 8443
base_directory = '/var/games/minecraft'
overwrite_web_root = '/mineos'

...
```
MineOS will now be available at https://myserveur.com/mineos/

See: #442