### PR TITLE
Update Makefile to add multi-arch build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REGISTRY_NAME :=
 REPOSITORY_NAME := hexparrot/
 IMAGE_NAME := mineos
 TAG := :latest
+PLATFORMS := linux/amd64,linux/arm/v7,linux/arm64
 
 .PHONY: getcommitid
 all: build
@@ -18,3 +19,13 @@ publish: build
 	docker push $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
 	docker push $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME):$(COMMITID)
 	docker logout
+
+build-multiarch: getcommitid
+        @docker buildx build --platform $(PLATFORMS) --tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME):$(COMMITID) -f Dockerfile .
+        @docker buildx build --platform $(PLATFORMS) --tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG) -f Dockerfile .
+
+publish-multiarch: build-multiarch
+        docker login
+        docker buildx build --push --platform $(PLATFORMS) --tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG) -f Dockerfile .
+        docker buildx build --push --platform $(PLATFORMS) --tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME):$(COMMITID) -f Dockerfile .
+        docker logout


### PR DESCRIPTION
Add ability to compile for multiple architectures like amd64 and ARM.

If you get this error
ERROR: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")

Create a buildx environment.

docker buildx create --name multiarch --driver docker-container --use

Then run make targets

Tested on Ubuntu 20.04.6 LTS with custom push to personal repo
https://hub.docker.com/r/greggee/mineos/tags
