### PR TITLE
Update Dockerfile - required for versions >= 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   rlwrap \
   unzip \
-  openjdk-17-jre-headless \
+  openjdk-21-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Updated Dockerfile for new version of Java

- Version 21 is required for 1.20.5 

Server does not start without it.

REF: https://www.minecraft.net/en-us/article/minecraft-java-edition-1-20-5

> The game now requires Java 21

Fixes:  https://github.com/hexparrot/mineos-node/issues/545