### PR TITLE
added openjdk-21-jre-headless to support Minecraft 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   rlwrap \
   unzip \
+  openjdk-21-jre-headless \
   openjdk-17-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
   git \
   curl \
   rlwrap \
+  openjdk-21-jre-headless \
   openjdk-17-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \


### PR DESCRIPTION
Updated docker files to install openjdk-21-jre-headless which is needed for Minecraft 1.21.