### PR TITLE
Update Java Version for Last Minecraft server and fix Timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   rlwrap \
   unzip \
-  openjdk-17-jre-headless \
+  openjdk-21-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       # with permissions that prevent normal users from accessing
       # the folder structure.
       - /var/games/mineos/minecraft:/var/games/minecraft
+       # Set timezone from the host
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
 
     environment:
       # Should the web interface use HTTPS or HTTP?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # with permissions that prevent normal users from accessing
       # the folder structure.
       - /var/games/mineos/minecraft:/var/games/minecraft
-       # Set timezone from the host
+      # Set timezone from the host
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
 


### PR DESCRIPTION
- Update the dockerfile to corresponding on the minimal version of java for actual minecraft server
- Update the docker compose to map the container timezone of the host timezone
