### PR TITLE
Update Dockerfile to include JRE 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   rlwrap \
   unzip \
+  openjdk-21-jre-headless \
   openjdk-17-jre-headless \
   openjdk-8-jre-headless \
   ca-certificates-java \


### PR DESCRIPTION
Minecraft 1.21 and beyond require JRE 21 to run