### PR TITLE
Bump userid from 1.0.0-beta.9 to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4250,12 +4250,19 @@
       }
     },
     "userid": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/userid/-/userid-1.0.0-beta.9.tgz",
-      "integrity": "sha512-TmOjGd7huXFpR0PgHRlBRD3p+pSlDrlEcKJaYFEU1eLB99JCEYoARUrQCES8nSJ+vIfYW3FZ5cMRR21DOVQUEw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/userid/-/userid-1.2.5.tgz",
+      "integrity": "sha512-pp9YrrSvnqQiMM6n0of9Y3K1K0snAmnwpPMe2W+icyTAeIWV3HXNCWd2f4ycVptdlqfXMT9AuoI5uOaTDkwVug==",
       "requires": {
         "bindings": "^1.5.0",
-        "node-addon-api": "^3.1.0"
+        "node-addon-api": "^4.0.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "tmp": "0.0.33",
     "unzipper": "0.10.11",
     "urllib": "^2.34.1",
-    "userid": "1.0.0-beta.9",
+    "userid": "1.2.5",
     "uuid": "3.0.x",
     "which": "1.2.x",
     "whoami": "0.0.x",


### PR DESCRIPTION
This solves a build failure on Debian Bookworm. We face the same error on all architectures: x86, ARM, 32-bit, 64-bit, RISC-V. Interestingly on Debian Bullseye and Trixie, it does not happen. Node versions are all the same latest v23.1.0 on all platforms, the Python 3 version is different, and the C++ compiler and library versions, where it seems so face a syntax error in `node-addon-api/napi.h`.

As it happenes during `userid` build, I recognised that the dependency is declared with a beta version. Checking available versions, it turns out stat `1.0.0-beta.9` was for whatever reason uploaded 4 seconds after stable `1.0.0` and hence seems unintentionally taken as latest `^1.0.0` by `npm`. However, there is a newer `1.2.5` release, and it seems to work fine with MineOS, solving the build issue in the same turn.

https://www.npmjs.com/package/userid?activeTab=versions

<details>
<summary>Log</summary>

```
2527 info run userid@1.0.0-beta.9 install node_modules/userid npm run build
2528 info run userid@1.0.0-beta.9 install { code: 1, signal: null }
2529 verbose stack Error: command failed
2529 verbose stack     at promiseSpawn (/usr/local/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:22:22)
2529 verbose stack     at spawnWithShell (/usr/local/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:124:10)
2529 verbose stack     at promiseSpawn (/usr/local/lib/node_modules/npm/node_modules/@npmcli/promise-spawn/lib/index.js:12:12)
2529 verbose stack     at runScriptPkg (/usr/local/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/run-script-pkg.js:77:13)
2529 verbose stack     at runScript (/usr/local/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/run-script.js:9:12)
2529 verbose stack     at /usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:329:17
2529 verbose stack     at run (/usr/local/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:67:22)
2529 verbose stack     at /usr/local/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:84:9
2529 verbose stack     at new Promise (<anonymous>)
2529 verbose stack     at callLimit (/usr/local/lib/node_modules/npm/node_modules/promise-call-limit/dist/commonjs/index.js:35:69)
2530 verbose pkgid userid@1.0.0-beta.9
2531 error code 1
2532 error path /mnt/dietpi_userdata/mineos/minecraft/node_modules/userid
2533 error command failed
2534 error command sh -c npm run build
2535 error > userid@1.0.0-beta.9 build
2535 error > node-gyp rebuild
2535 error
2535 error
2535 error make: Entering directory '/mnt/dietpi_userdata/mineos/minecraft/node_modules/userid/build'
2535 error   CXX(target) Release/obj.target/userid/src/Gid.o
2535 error make: Leaving directory '/mnt/dietpi_userdata/mineos/minecraft/node_modules/userid/build'
2536 error gyp info it worked if it ends with ok
2536 error gyp info using node-gyp@10.2.0
2536 error gyp info using node@23.1.0 | linux | x64
2536 error gyp info find Python using Python version 3.11.2 found at "/usr/bin/python3"
2536 error (node:9915) ExperimentalWarning: CommonJS module /usr/local/lib/node_modules/npm/node_modules/debug/src/node.js is loading ES Module /usr/local/lib/node_modules/npm/node_modules/supports-color/index.js using require().
2536 error Support for loading ES Module in require() is an experimental feature and might change at any time
2536 error (Use `node --trace-warnings ...` to show where the warning was created)
2536 error gyp info spawn /usr/bin/python3
2536 error gyp info spawn args [
2536 error gyp info spawn args '/usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
2536 error gyp info spawn args 'binding.gyp',
2536 error gyp info spawn args '-f',
2536 error gyp info spawn args 'make',
2536 error gyp info spawn args '-I',
2536 error gyp info spawn args '/mnt/dietpi_userdata/mineos/minecraft/node_modules/userid/build/config.gypi',
2536 error gyp info spawn args '-I',
2536 error gyp info spawn args '/usr/local/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
2536 error gyp info spawn args '-I',
2536 error gyp info spawn args '/root/.cache/node-gyp/23.1.0/include/node/common.gypi',
2536 error gyp info spawn args '-Dlibrary=shared_library',
2536 error gyp info spawn args '-Dvisibility=default',
2536 error gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/23.1.0',
2536 error gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/npm/node_modules/node-gyp',
2536 error gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/23.1.0/<(target_arch)/node.lib',
2536 error gyp info spawn args '-Dmodule_root_dir=/mnt/dietpi_userdata/mineos/minecraft/node_modules/userid',
2536 error gyp info spawn args '-Dnode_engine=v8',
2536 error gyp info spawn args '--depth=.',
2536 error gyp info spawn args '--no-parallel',
2536 error gyp info spawn args '--generator-output',
2536 error gyp info spawn args 'build',
2536 error gyp info spawn args '-Goutput_dir=.'
2536 error gyp info spawn args ]
2536 error gyp info spawn make
2536 error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2536 error In file included from ../src/userid.hh:4,
2536 error                  from ../src/Gid.cc:4:
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2388:60: error: expected unqualified-id before ‘)’ token
2536 error  2388 |     TypedThreadSafeFunction<ContextType, DataType, CallJs>();
2536 error       |                                                            ^
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2390:33: error: expected ‘)’ before ‘tsFunctionValue’
2536 error  2390 |         napi_threadsafe_function tsFunctionValue);
2536 error       |                                 ^~~~~~~~~~~~~~~~
2536 error       |                                 )
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2389:59: note: to match this ‘(’
2536 error  2389 |     TypedThreadSafeFunction<ContextType, DataType, CallJs>(
2536 error       |                                                           ^
2536 error In file included from /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2636:
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi-inl.h:4726:8: error: no declaration matches ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction()’
2536 error  4726 | inline TypedThreadSafeFunction<ContextType, DataType, CallJs>::
2536 error       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi-inl.h:4726:8: note: no functions named ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction()’
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2258:9: note: ‘class Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>’ defined here
2536 error  2258 |   class TypedThreadSafeFunction {
2536 error       |         ^~~~~~~~~~~~~~~~~~~~~~~
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi-inl.h:4733:8: error: no declaration matches ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction(napi_threadsafe_function)’
2536 error  4733 | inline TypedThreadSafeFunction<ContextType, DataType, CallJs>::
2536 error       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi-inl.h:4733:8: note: no functions named ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction(napi_threadsafe_function)’
2536 error /mnt/dietpi_userdata/mineos/minecraft/node_modules/node-addon-api/napi.h:2258:9: note: ‘class Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>’ defined here
2536 error  2258 |   class TypedThreadSafeFunction {
2536 error       |         ^~~~~~~~~~~~~~~~~~~~~~~
2536 error make: *** [userid.target.mk:113: Release/obj.target/userid/src/Gid.o] Error 1
2536 error gyp ERR! build error 
2536 error gyp ERR! stack Error: `make` failed with exit code: 2
2536 error gyp ERR! stack at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:216:23)
2536 error gyp ERR! System Linux 6.1.0-26-amd64
2536 error gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
2536 error gyp ERR! cwd /mnt/dietpi_userdata/mineos/minecraft/node_modules/userid
2536 error gyp ERR! node -v v23.1.0
2536 error gyp ERR! node-gyp -v v10.2.0
2536 error gyp ERR! not ok
```

</details>